### PR TITLE
examples/sandboxed-tools: pluggable toolsets + gemini-cli toolset in Go

### DIFF
--- a/dev/tools/push-images
+++ b/dev/tools/push-images
@@ -220,6 +220,11 @@ def main(args):
             if root == sandboxd_dir:
                 context_dir = "."
 
+            # The geminicli-toolbox image also imports the shared Go module,
+            # so it too builds from the repo root.
+            if service_name == "geminicli-toolbox":
+                context_dir = "."
+
             if args.controller_only and service_name != "agent-sandbox-controller":
                 continue
 

--- a/examples/sandboxed-tools/README.md
+++ b/examples/sandboxed-tools/README.md
@@ -7,8 +7,9 @@ By reusing a sandbox and automatically extending its inactivity timeout, we avoi
 ## Architecture & Key Concepts
 
 1. **Minimal OpenAI-Compatible Client (`pkg/llm`)**: A lightweight Go client built on `net/http` without a third-party OpenAI SDK that interacts with OpenAI-compatible API endpoints (such as the Gemini API via its OpenAI compatibility layer). It supports function calling (tools) and tool call responses.
-2. **Sandbox Reuse**: The application provisions a sandbox pod on the first tool call of a session, and reuses it for subsequent tool calls. This keeps the execution overhead low.
-3. **Session Persistence via Snapshots**: To maintain continuity across conversation turns and protect against inactivity cleanups or CLI restarts:
+2. **Pluggable Toolsets (`pkg/toolsets`)**: The tools and the system prompt are bundled into a *toolset*, selected with the `-toolset` flag. A toolset also declares the sandbox image it expects, so switching toolsets switches the whole agent profile. Two toolsets are provided: `basic` (the original minimal tools) and `geminicli` (the [gemini-cli](https://github.com/google-gemini/gemini-cli) tool surface, reimplemented in Go — see below).
+3. **Sandbox Reuse**: The application provisions a sandbox pod on the first tool call of a session, and reuses it for subsequent tool calls. This keeps the execution overhead low.
+4. **Session Persistence via Snapshots**: To maintain continuity across conversation turns and protect against inactivity cleanups or CLI restarts:
    - The application automatically snapshots the sandbox's home directory (`/home/clawtainer` by default) after tool executions at conversation boundaries.
    - These snapshots are saved as local tarball files on the host machine under `~/.local/sandboxed-tools/<session>/fs/backup-*.tar.gz`.
    - Only the last 5 backups are retained per session; older backups are automatically pruned.
@@ -22,7 +23,8 @@ The application accepts the following command-line flags:
 | :--- | :--- | :--- |
 | `-session` | **Required**. A unique alphanumeric name (max 40 characters) to identify this agent session and store/restore its filesystem snapshots. | None |
 | `-namespace`| The Kubernetes namespace where sandbox pods are created. | `default` (overrides `SANDBOX_NAMESPACE` env var) |
-| `-image` | The container image used for the temporary sandbox pod. | `debian:bookworm-slim` (overrides `SANDBOX_IMAGE` env var) |
+| `-toolset` | The toolset (tools + system prompt) to expose to the LLM: `basic` or `geminicli`. | `basic` (overrides `TOOLSET` env var) |
+| `-image` | The container image used for the temporary sandbox pod. Precedence: this flag, then `SANDBOX_IMAGE`, then the toolset's default image, then `debian:bookworm-slim`. | Toolset default |
 | `-homedir` | The directory inside the sandbox that is persisted via snapshot/restore. | `/home/clawtainer` (overrides `SANDBOX_HOME_DIR` env var) |
 | `-tool-timeout` | Maximum duration a single tool invocation (`run_command`, `ls`, `read`, or `write`) may run before it is cancelled. Accepts Go duration syntax, e.g. `30s`, `2m`, `1h`. `<= 0` disables the timeout. | `2m` |
 
@@ -37,18 +39,47 @@ The application is configured via environment variables (usually for API keys an
 | `GEMINI_API_KEY` | Your Gemini API key (or `OPENAI_API_KEY`). | **Required** |
 | `OPENAI_BASE_URL` | The base URL for the OpenAI-compatible API. | `https://generativelanguage.googleapis.com/v1beta/openai` |
 | `OPENAI_MODEL` | The model name to use for chat completions (or `MODEL`). | `gemini-3.5-flash` |
-| `SANDBOX_IMAGE` | Fallback container image if `-image` flag is not set. | `debian:bookworm-slim` |
+| `SANDBOX_IMAGE` | Fallback container image if `-image` flag is not set. | Toolset default |
 | `SANDBOX_NAMESPACE`| Fallback Kubernetes namespace if `-namespace` flag is not set. | `default` |
 | `SANDBOX_HOME_DIR` | Fallback persisted directory if `-homedir` flag is not set. | `/home/clawtainer` |
+| `TOOLSET` | Fallback toolset if `-toolset` flag is not set. | `basic` |
 
-## Available Tools
+## Toolsets
 
-The LLM has access to a powerful suite of tools configured in the registry (`pkg/tools`):
+The tools and the system prompt are pluggable: each *toolset* (`pkg/toolsets`) bundles a system prompt, a set of LLM-callable tools, and the sandbox image those tools need. Select one with `-toolset`.
+
+### `basic` (default)
+
+A minimal, image-agnostic toolset (`pkg/toolsets/basic`) that works on any sandbox image with standard POSIX utilities:
 
 * **`run_command`**: Executes an arbitrary shell command inside the sandbox container, returning `stdout`, `stderr`, and the `exit_code`.
 * **`ls`**: Lists the files and directories inside a specific folder (defaults to the current directory).
 * **`read`**: Reads the full contents of a file from the sandbox.
 * **`write`**: Writes specified content to a file, automatically creating parent directories if they do not exist and overwriting the file if it does.
+
+### `geminicli`
+
+A toolset (`pkg/toolsets/geminicli`) that reproduces the tool surface and system prompt of [gemini-cli](https://github.com/google-gemini/gemini-cli) (Apache-2.0), so models tuned for gemini-cli behave the same way inside an Agent Sandbox. The tools are reimplemented in Go — no Node.js runtime is required in the sandbox:
+
+* **`run_shell_command`**: Executes a bash command (with background-process support via `is_background`).
+* **`list_directory`**: Lists a directory (directories first, with sizes and ignore globs).
+* **`read_file`**: Reads a file, with `start_line`/`end_line` ranges and truncation hints for large files.
+* **`write_file`**: Writes full file content, creating parent directories.
+* **`replace`**: Exact-literal-string edits, failing loudly on ambiguous or missing `old_string`.
+* **`glob`**: Finds files by glob pattern (`**`, `{a,b}` supported), newest first.
+* **`grep_search`**: Regex content search with include globs, context lines, and match caps.
+* **`read_many_files`**: Bulk-reads files matching glob patterns into one response.
+
+The filesystem tools are implemented by a small Go helper binary, **`geminicli-toolbox`** (`cmd/geminicli-toolbox` + `pkg/toolsets/geminicli/toolbox`), which runs *inside* the sandbox: the agent execs `geminicli-toolbox <tool-name>` with the tool arguments as JSON on stdin and reads the result from stdout. This keeps tool semantics (glob matching, exact-string edits, truncation) deterministic and fast, without depending on which utilities the base image ships.
+
+The sandbox image for this toolset therefore has to include the `geminicli-toolbox` binary. Build it from the repository root and make it available to your cluster (for kind):
+
+```bash
+docker build -t kind.local/geminicli-toolbox:dev -f examples/sandboxed-tools/images/geminicli-toolbox/Dockerfile .
+kind load docker-image kind.local/geminicli-toolbox:dev --name agent-sandbox
+
+go run ./examples/sandboxed-tools/cmd/sandboxed-tools-cli -session mysession -toolset geminicli -image kind.local/geminicli-toolbox:dev
+```
 
 ## Fake LLM for Testing
 

--- a/examples/sandboxed-tools/cmd/geminicli-toolbox/main.go
+++ b/examples/sandboxed-tools/cmd/geminicli-toolbox/main.go
@@ -1,0 +1,78 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// geminicli-toolbox implements the filesystem tools of the geminicli toolset.
+// It runs inside the sandbox: the host-side agent execs
+// `geminicli-toolbox <tool-name>` with the LLM's tool arguments as JSON on
+// stdin, and reads the model-facing result from stdout. A non-zero exit code
+// indicates the tool call failed; the reason is written to stderr.
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"sigs.k8s.io/agent-sandbox/examples/sandboxed-tools/pkg/toolsets/geminicli/toolbox"
+)
+
+func main() {
+	if err := run(context.Background()); err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+}
+
+func run(ctx context.Context) error {
+	// Relative paths in tool arguments resolve against the workspace root:
+	// by default the sandbox home directory, which is the directory the
+	// sandboxed-tools agent persists across sandbox restarts.
+	workdir := os.Getenv("HOME")
+	flag.StringVar(&workdir, "workdir", workdir, "workspace root that relative paths resolve against")
+	flag.Parse()
+
+	if flag.NArg() != 1 {
+		return fmt.Errorf("usage: geminicli-toolbox [--workdir=DIR] TOOL_NAME (tool parameters as JSON on stdin)")
+	}
+	toolName := flag.Arg(0)
+
+	if workdir == "" {
+		cwd, err := os.Getwd()
+		if err != nil {
+			return fmt.Errorf("cannot determine workspace root ($HOME and cwd unavailable): %w", err)
+		}
+		workdir = cwd
+	}
+
+	params, err := io.ReadAll(os.Stdin)
+	if err != nil {
+		return fmt.Errorf("failed to read tool parameters from stdin: %w", err)
+	}
+
+	result, err := toolbox.Run(ctx, workdir, toolName, params)
+	if err != nil {
+		return err
+	}
+
+	if _, err := os.Stdout.WriteString(result); err != nil {
+		return fmt.Errorf("failed to write result: %w", err)
+	}
+	if !strings.HasSuffix(result, "\n") {
+		fmt.Println()
+	}
+	return nil
+}

--- a/examples/sandboxed-tools/cmd/sandboxed-tools-cli/main.go
+++ b/examples/sandboxed-tools/cmd/sandboxed-tools-cli/main.go
@@ -34,6 +34,7 @@ import (
 	"sigs.k8s.io/agent-sandbox/examples/sandboxed-tools/pkg/llm"
 	"sigs.k8s.io/agent-sandbox/examples/sandboxed-tools/pkg/sessions"
 	"sigs.k8s.io/agent-sandbox/examples/sandboxed-tools/pkg/tools"
+	"sigs.k8s.io/agent-sandbox/examples/sandboxed-tools/pkg/toolsets"
 )
 
 func main() {
@@ -63,18 +64,21 @@ func main() {
 		sessionName = "default"
 	}
 
+	toolsetName := os.Getenv("TOOLSET")
+
 	var opts agent.RunOptions
 	opts.InitDefaults()
 	flag.StringVar(&sessionName, "session", sessionName, "session name")
 	flag.StringVar(&opts.Namespace, "namespace", opts.Namespace, "namespace")
-	flag.StringVar(&opts.Image, "image", opts.Image, "image")
+	flag.StringVar(&opts.Image, "image", opts.Image, "Sandbox container image; if empty, uses the toolset's default image.")
 	flag.StringVar(&opts.HomeDir, "homedir", opts.HomeDir, "Home directory in the sandbox; this is currently the only directory that we persist with snapshot/restore.")
+	flag.StringVar(&toolsetName, "toolset", toolsetName, fmt.Sprintf("Toolset (tools + system prompt) to expose to the LLM; one of: %s", strings.Join(toolsets.Names(), ", ")))
 	flag.DurationVar(&opts.ToolTimeout, "tool-timeout", opts.ToolTimeout, "Maximum duration a single tool invocation may run before it is cancelled (Go duration syntax, e.g. \"30s\", \"2m\"). <= 0 disables the timeout.")
 	flag.Parse()
 
 	log := klog.FromContext(ctx)
 
-	if err := run(signalCtx, opts, sessionName); err != nil {
+	if err := run(signalCtx, opts, sessionName, toolsetName); err != nil {
 		if errors.Is(err, context.Canceled) {
 			fmt.Fprintf(os.Stderr, "\n")
 			log.V(1).Info("context cancelled")
@@ -85,7 +89,7 @@ func main() {
 	}
 }
 
-func run(ctx context.Context, opts agent.RunOptions, sessionName string) error {
+func run(ctx context.Context, opts agent.RunOptions, sessionName string, toolsetName string) error {
 	log := klog.FromContext(ctx)
 
 	if opts.HomeDir == "" {
@@ -98,6 +102,21 @@ func run(ctx context.Context, opts agent.RunOptions, sessionName string) error {
 
 	if err := sessions.ValidateSessionName(sessionName); err != nil {
 		return fmt.Errorf("invalid sessionName %q: %w", sessionName, err)
+	}
+
+	toolset, err := toolsets.Get(toolsetName)
+	if err != nil {
+		return err
+	}
+	opts.SystemPrompt = toolset.SystemPrompt()
+
+	// Image precedence: -image flag / SANDBOX_IMAGE env, then the toolset's
+	// preferred image, then the generic default.
+	if opts.Image == "" {
+		opts.Image = toolset.DefaultImage()
+	}
+	if opts.Image == "" {
+		opts.Image = agent.DefaultImage
 	}
 
 	llmClient, err := llm.NewFromEnv(opts.ModelName)
@@ -123,11 +142,7 @@ func run(ctx context.Context, opts agent.RunOptions, sessionName string) error {
 
 	toolsRegistry := tools.NewRegistry()
 	toolsRegistry.ToolTimeout = opts.ToolTimeout
-	toolsRegistry.Add(&tools.RunCommand{})
-
-	toolsRegistry.Add(&tools.ListFilesTool{})
-	toolsRegistry.Add(&tools.ReadFileTool{})
-	toolsRegistry.Add(&tools.WriteFileTool{})
+	toolset.RegisterTools(toolsRegistry)
 
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
@@ -161,6 +176,10 @@ func runREPL(ctx context.Context, harness *agent.Harness, session *agent.Session
 		fmt.Println("Type your message (or '/exit' or '/quit' to quit):")
 		fmt.Println("================================================================================")
 	} else {
+		// Note that it's possible that the tools are different from the original toolset.
+		// We are allowed to change the tools, (at the expense of the KV cache),
+		// whether this is useful or not in practice .... let's find out!
+
 		fmt.Println("================================================================================")
 		fmt.Printf("Resumed session %q with %d messages in history:\n", session.Name, len(session.Messages()))
 		fmt.Println("================================================================================")

--- a/examples/sandboxed-tools/images/geminicli-toolbox/Dockerfile
+++ b/examples/sandboxed-tools/images/geminicli-toolbox/Dockerfile
@@ -1,0 +1,45 @@
+# Sandbox image for the "geminicli" toolset of the sandboxed-tools example.
+#
+# It bundles the geminicli-toolbox binary (the Go implementation of the
+# gemini-cli filesystem tools, see
+# examples/sandboxed-tools/pkg/toolsets/geminicli/toolbox) on top of a small
+# Debian base that provides bash and git for run_shell_command.
+#
+# Build from the REPOSITORY ROOT (the build needs the Go module context):
+#
+#   docker build -t geminicli-toolbox:latest \
+#     -f examples/sandboxed-tools/images/geminicli-toolbox/Dockerfile .
+#
+# For a kind cluster (e.g. created by `make deploy-kind`):
+#
+#   kind load docker-image geminicli-toolbox:latest --name agent-sandbox
+#
+# Then run the example with the geminicli toolset, which uses this image by
+# default:
+#
+#   go run ./examples/sandboxed-tools/cmd/sandboxed-tools-cli \
+#     -session mysession -toolset geminicli
+
+FROM golang:1.26-bookworm AS build
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+COPY examples/sandboxed-tools ./examples/sandboxed-tools
+# -buildvcs=false: the build context includes .git, but git metadata is not
+# usable inside the build container (and version stamping is not needed here).
+RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -buildvcs=false -ldflags="-s -w" \
+      -o /geminicli-toolbox ./examples/sandboxed-tools/cmd/geminicli-toolbox
+
+FROM debian:bookworm-slim
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates git curl procps \
+    && rm -rf /var/lib/apt/lists/*
+COPY --from=build /geminicli-toolbox /usr/local/bin/geminicli-toolbox
+
+# Note: we run as root; we can later investigate running as non-root
+# and whether this reduces functionality / eval-scores in the sandbox.
+
+# The sandboxed-tools agent overrides the command with "sleep infinity" and
+# execs tools into the container; this default just keeps the container alive
+# if the image is run directly.
+CMD ["sleep", "infinity"]

--- a/examples/sandboxed-tools/pkg/agent/agent.go
+++ b/examples/sandboxed-tools/pkg/agent/agent.go
@@ -58,11 +58,6 @@ const SandboxInactivityTimeout = 5 * time.Minute
 // of blocking the agent loop indefinitely.
 const DefaultToolTimeout = 2 * time.Minute
 
-// systemPrompt seeds every new session.
-const systemPrompt = "You are a helpful AI assistant with access to a sandboxed environment. " +
-	"You can use the available tools (like run_command to execute shell commands, ls to list files, read to read files, and write to write files) to answer user questions or perform tasks. " +
-	"Always explain what you are doing."
-
 // SandboxClient is a simple low-level client for managing Sandbox resources directly.
 type SandboxClient struct {
 	agentsClient agentsclientset.Interface
@@ -612,17 +607,25 @@ type RunOptions struct {
 	// ModelName is the name of the model to use with the LLM.
 	ModelName string
 
+	// SystemPrompt seeds every new session. It is provided by the selected
+	// toolset, so the prompt always matches the registered tools.
+	SystemPrompt string
+
 	// ToolTimeout bounds how long a single tool invocation may run before it
 	// is cancelled. <= 0 disables the timeout. Default: DefaultToolTimeout.
 	ToolTimeout time.Duration
 }
 
+// DefaultImage is the sandbox image used when neither the flags, the
+// environment, nor the selected toolset specify one.
+const DefaultImage = "debian:bookworm-slim"
+
 // InitDefaults populates the options from environment variables and defaults.
+// Image is left empty when SANDBOX_IMAGE is unset, so callers can
+// distinguish "unset" from an explicit choice and apply the toolset's
+// default image (falling back to DefaultImage).
 func (o *RunOptions) InitDefaults() {
 	o.Image = os.Getenv("SANDBOX_IMAGE")
-	if o.Image == "" {
-		o.Image = "debian:bookworm-slim"
-	}
 
 	o.Namespace = os.Getenv("SANDBOX_NAMESPACE")
 	if o.Namespace == "" {
@@ -724,13 +727,16 @@ func (h *Harness) BuildSession(ctx context.Context, sessionStore sessions.Store,
 	return session, nil
 }
 
-// EnsureSystemPrompt seeds a new session with the system prompt. It is a
-// no-op for resumed sessions that already have history.
+// EnsureSystemPrompt seeds a new session with the configured system prompt.
+// It is a no-op for resumed sessions that already have history.
 func (h *Harness) EnsureSystemPrompt(ctx context.Context, session *Session) error {
 	if len(session.messages) > 0 {
 		return nil
 	}
-	prompt := systemPrompt
+	if h.opts.SystemPrompt == "" {
+		return fmt.Errorf("SystemPrompt is not configured")
+	}
+	prompt := h.opts.SystemPrompt
 	return session.AddMessages(ctx, llm.Message{Role: "system", Content: &prompt})
 }
 

--- a/examples/sandboxed-tools/pkg/tools/limited_writer.go
+++ b/examples/sandboxed-tools/pkg/tools/limited_writer.go
@@ -1,0 +1,74 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tools
+
+import (
+	"bytes"
+	"sync"
+)
+
+// LimitedWriter is a Writer that limits the amount of data that can be written to it.
+// It is also safe for concurrent use by multiple goroutines (e.g. multiple writers).
+type LimitedWriter struct {
+	mutex     sync.Mutex
+	buffer    bytes.Buffer
+	limit     int
+	truncated bool
+}
+
+func (w *LimitedWriter) Write(p []byte) (int, error) {
+	w.mutex.Lock()
+	defer w.mutex.Unlock()
+
+	if w.truncated {
+		return len(p), nil
+	}
+	if w.limit != 0 {
+		remaining := w.limit - w.buffer.Len()
+		if remaining <= 0 {
+			w.truncated = true
+			return len(p), nil
+		}
+		if len(p) > remaining {
+			_, _ = w.buffer.Write(p[:remaining])
+			w.truncated = true
+			return len(p), nil
+		}
+	}
+	return w.buffer.Write(p)
+}
+
+func (w *LimitedWriter) String() string {
+	w.mutex.Lock()
+	defer w.mutex.Unlock()
+	return w.buffer.String()
+}
+
+func (w *LimitedWriter) Truncated() bool {
+	w.mutex.Lock()
+	defer w.mutex.Unlock()
+	return w.truncated
+}
+
+func (w *LimitedWriter) Len() int {
+	w.mutex.Lock()
+	defer w.mutex.Unlock()
+	return w.buffer.Len()
+}
+
+// NewLimitedWriter creates a new LimitedWriter with the given limit.
+func NewLimitedWriter(limit int) *LimitedWriter {
+	return &LimitedWriter{limit: limit}
+}

--- a/examples/sandboxed-tools/pkg/tools/limited_writer_test.go
+++ b/examples/sandboxed-tools/pkg/tools/limited_writer_test.go
@@ -1,0 +1,48 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tools
+
+import "testing"
+
+func TestLimitedWriter(t *testing.T) {
+	w := NewLimitedWriter(8)
+	n, err := w.Write([]byte("hello"))
+	if err != nil {
+		t.Errorf("Error writing to LimitedWriter: %v", err)
+	}
+	if n != 5 {
+		t.Errorf("Expected %d bytes written, got %d", 5, n)
+	}
+	if w.String() != "hello" {
+		t.Errorf("Expected %q, got %q", "hello", w.String())
+	}
+	if w.Truncated() {
+		t.Errorf("Expected not truncated, got truncated")
+	}
+
+	n, err = w.Write([]byte("world"))
+	if err != nil {
+		t.Errorf("Error writing to LimitedWriter: %v", err)
+	}
+	if n != 5 {
+		t.Errorf("Expected %d bytes written, got %d", 5, n)
+	}
+	if w.String() != "hellowor" {
+		t.Errorf("Expected %q, got %q", "hellowor", w.String())
+	}
+	if !w.Truncated() {
+		t.Errorf("Expected truncated, got not truncated")
+	}
+}

--- a/examples/sandboxed-tools/pkg/toolsets/basic/basic.go
+++ b/examples/sandboxed-tools/pkg/toolsets/basic/basic.go
@@ -1,0 +1,59 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package basic is the original sandboxed-tools toolset: a minimal set of
+// generic tools (run_command, ls, read, write) with a short system prompt.
+// It works with any sandbox image that provides standard POSIX utilities.
+package basic
+
+import (
+	"sigs.k8s.io/agent-sandbox/examples/sandboxed-tools/pkg/tools"
+)
+
+// systemPrompt seeds every new session that uses the basic toolset.
+const systemPrompt = "You are a helpful AI assistant with access to a sandboxed environment. " +
+	"You can use the available tools (like run_command to execute shell commands, ls to list files, read to read files, and write to write files) to answer user questions or perform tasks. " +
+	"Always explain what you are doing."
+
+// Toolset is the basic sandboxed-tools toolset.
+type Toolset struct{}
+
+// New returns the basic toolset.
+func New() *Toolset {
+	return &Toolset{}
+}
+
+// Name implements toolsets.Toolset.
+func (t *Toolset) Name() string {
+	return "basic"
+}
+
+// SystemPrompt implements toolsets.Toolset.
+func (t *Toolset) SystemPrompt() string {
+	return systemPrompt
+}
+
+// RegisterTools implements toolsets.Toolset.
+func (t *Toolset) RegisterTools(registry *tools.Registry) {
+	registry.Add(&tools.RunCommand{})
+	registry.Add(&tools.ListFilesTool{})
+	registry.Add(&tools.ReadFileTool{})
+	registry.Add(&tools.WriteFileTool{})
+}
+
+// DefaultImage implements toolsets.Toolset. The basic tools only need
+// standard POSIX utilities, so any generic image will do.
+func (t *Toolset) DefaultImage() string {
+	return ""
+}

--- a/examples/sandboxed-tools/pkg/toolsets/geminicli/prompt.go
+++ b/examples/sandboxed-tools/pkg/toolsets/geminicli/prompt.go
@@ -1,0 +1,174 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package geminicli
+
+// systemPrompt is derived from gemini-cli's core system prompt
+// (https://github.com/google-gemini/gemini-cli,
+// packages/core/src/prompts/snippets.ts), Copyright Google LLC, licensed
+// under the Apache License 2.0.
+//
+// It uses the non-interactive ("autonomous") variants of each section, and is
+// adapted to the tool subset this toolset provides: the sections covering
+// features we do not implement (sub-agents, skills, plan mode, task tracker,
+// topic updates, write_todos, ask_user, GEMINI.md context files) are omitted,
+// and the Sandbox section is rewritten to describe the Agent Sandbox
+// environment. The remaining text is kept close to the original so that model
+// behavior tuned for gemini-cli transfers to this toolset. See
+// Toolset.RegisterTools (toolset.go) for the inventory of missing tools; as
+// tools are added, the corresponding prompt sections should be restored from
+// gemini-cli's packages/core/src/prompts/snippets.ts.
+//
+// TODO: gemini-cli loads GEMINI.md context files (global, workspace, and
+// per-directory) into the prompt via a "Contextual Instructions" section and
+// gives them precedence over the system prompt defaults. Loading GEMINI.md
+// from the sandbox home directory at session start would be the natural
+// equivalent here.
+//
+// TODO: gemini-cli wraps external tool/MCP output in <untrusted_context> tags
+// and the prompt instructs the model to treat that content as passive data
+// (prompt-injection hardening). Our harness does not tag tool output, so
+// that mandate is omitted; restore it if/when the harness adds wrapping.
+const systemPrompt = `You are Gemini CLI, an autonomous CLI agent specializing in software engineering tasks. Your primary goal is to help users safely and effectively.
+
+# Core Mandates
+
+## Security & System Integrity
+- **Credential Protection:** Never log, print, or commit secrets, API keys, or sensitive credentials. Rigorously protect ` + "`.env`" + ` files, ` + "`.git`" + `, and system configuration folders.
+- **Source Control:** Do not stage or commit changes unless specifically requested by the user.
+
+## Context Efficiency:
+Be strategic in your use of the available tools to minimize unnecessary context usage while still
+providing the best answer that you can.
+
+Consider the following when estimating the cost of your approach:
+<estimating_context_usage>
+- The agent passes the full history with each subsequent message. The larger context is early in the session, the more expensive each subsequent turn is.
+- Unnecessary turns are generally more expensive than other types of wasted context.
+- You can reduce context usage by limiting the outputs of tools but take care not to cause more token consumption via additional turns required to recover from a tool failure or compensate for a misapplied optimization strategy.
+</estimating_context_usage>
+
+Use the following guidelines to optimize your search and read patterns.
+<guidelines>
+- Combine turns whenever possible by utilizing parallel searching and reading and by requesting enough context by passing context, before, or after to grep_search, to enable you to skip using an extra turn reading the file.
+- Prefer using tools like grep_search to identify points of interest instead of reading lots of files individually.
+- If you need to read multiple ranges in a file, do so in as few turns as possible.
+- It is more important to reduce extra turns, but please also try to minimize unnecessarily large file reads and search results, when doing so doesn't result in extra turns. Do this by always providing conservative limits and scopes to tools like read_file and grep_search.
+- replace fails if old_string is ambiguous, causing extra turns. Take care to read enough with read_file and grep_search to make the edit unambiguous.
+- You can compensate for the risk of missing results with scoped or limited searches by doing multiple searches.
+- Your primary goal is still to do your best quality work. Efficiency is an important, but secondary concern.
+</guidelines>
+
+<examples>
+- **Searching:** utilize search tools like grep_search and glob with a conservative result count (` + "`total_max_matches`" + `) and a narrow scope (` + "`include_pattern`" + ` and ` + "`exclude_pattern`" + ` parameters).
+- **Searching and editing:** utilize search tools like grep_search with a conservative result count and a narrow scope. Use ` + "`context`" + `, ` + "`before`" + `, and/or ` + "`after`" + ` to request enough context to avoid the need to read the file before editing matches.
+- **Understanding:** minimize turns needed to understand a file. It's most efficient to read small files in their entirety.
+- **Large files:** utilize search tools like grep_search and/or read_file with 'start_line' and 'end_line' to reduce the impact on context. Minimize extra turns, unless unavoidable due to the file being too large.
+- **Navigating:** read the minimum required to not require additional turns spent reading the file.
+</examples>
+
+## Engineering Standards
+- **Conventions & Style:** Rigorously adhere to existing workspace conventions, architectural patterns, and style (naming, formatting, typing, commenting). During the research phase, analyze surrounding files, tests, and configuration to ensure your changes are seamless, idiomatic, and consistent with the local context. Never compromise idiomatic quality or completeness (e.g., proper declarations, type safety, documentation) to minimize tool calls; all supporting changes required by local conventions are part of a surgical update.
+- **Types, warnings and linters:** NEVER use hacks like disabling or suppressing warnings, bypassing the type system, or employing "hidden" logic unless explicitly instructed to by the user. Instead, use explicit and idiomatic language features that maintain structural integrity and type safety.
+- **Libraries/Frameworks:** NEVER assume a library/framework is available. Verify its established usage within the project (check imports, configuration files like 'package.json', 'Cargo.toml', 'requirements.txt', etc.) before employing it.
+- **Technical Integrity:** You are responsible for the entire lifecycle: implementation, testing, and validation. Within the scope of your changes, prioritize readability and long-term maintainability by consolidating logic into clean abstractions rather than threading state across unrelated layers. Align strictly with the requested architectural direction, ensuring the final implementation is focused and free of redundant "just-in-case" alternatives. For bug fixes, you must empirically reproduce the failure with a new test case or reproduction script before applying the fix.
+- **Expertise & Intent Alignment:** Provide proactive technical opinions grounded in research while strictly adhering to the user's intended workflow. Distinguish between **Directives** (unambiguous requests for action or implementation) and **Inquiries** (requests for analysis, advice, or observations). Assume all requests are Inquiries unless they contain an explicit instruction to perform a task. For Inquiries, your scope is strictly limited to research and analysis; you may propose a solution or strategy, but you MUST NOT modify files until a subsequent Directive is issued. For Directives, you must work autonomously as no further user input is available.
+- **Proactiveness:** When executing a Directive, persist through errors and obstacles by diagnosing failures in the execution phase and, if necessary, backtracking to the research or strategy phases to adjust your approach until a successful, verified outcome is achieved. Fulfill the user's request thoroughly, including adding tests when adding features or fixing bugs.
+- **Testing:** ALWAYS search for and update related tests after making a code change. You must add a new test case to the existing test file (if one exists) or create a new test file to verify your changes.
+- **Handle Ambiguity/Expansion:** Do not take significant actions beyond the clear scope of the request. If the user implies a change (e.g., reports a bug) without explicitly asking for a fix, do not perform it automatically.
+- **Explain Before Acting:** Never call tools in silence. You MUST provide a concise, one-sentence explanation of your intent or strategy immediately before executing tool calls. Silence is only acceptable for repetitive, low-level discovery operations (e.g., sequential file reads) where narration would be noisy.
+- **Do Not revert changes:** Do not revert changes to the codebase unless asked to do so by the user. Only revert changes made by you if they have resulted in an error or if the user has explicitly asked you to revert the changes.
+- **Non-Interactive Environment:** You are running in a headless environment and cannot reliably interact with the user mid-task. Use your best judgment to complete the task. If a tool fails because it requires user interaction, do not retry it indefinitely; instead, explain the limitation and suggest how the user can provide the required data (e.g., via environment variables).
+
+# Primary Workflows
+
+## Development Lifecycle
+Operate using a **Research -> Strategy -> Execution** lifecycle. For the Execution phase, resolve each sub-task through an iterative **Plan -> Act -> Validate** cycle.
+
+1. **Research:** Systematically map the codebase and validate assumptions. Use grep_search and glob search tools extensively to understand file structures, existing code patterns, and conventions. Use read_file to validate all assumptions. **Prioritize empirical reproduction of reported issues to confirm the failure state.**
+2. **Strategy:** Formulate a grounded plan based on your research.
+3. **Execution:** For each sub-task:
+   - **Plan:** Define the specific implementation approach **and the testing strategy to verify the change.**
+   - **Act:** Apply targeted, surgical changes strictly related to the sub-task. Use the available tools (e.g., replace, write_file, run_shell_command). Ensure changes are idiomatically complete and follow all workspace standards, even if it requires multiple tool calls. **Include necessary automated tests; a change is incomplete without verification logic.** Avoid unrelated refactoring or "cleanup" of outside code. Before making manual code changes, check if an ecosystem tool (like 'eslint --fix', 'prettier --write', 'go fmt', 'cargo fmt') is available in the project to perform the task automatically.
+   - **Validate:** Run tests and workspace standards to confirm the success of the specific change and ensure no regressions were introduced. After making code changes, execute the project-specific build, linting and type-checking commands (e.g., 'tsc', 'npm run lint', 'ruff check .') that you have identified for this project.
+
+**Validation is the only path to finality.** Never assume success or settle for unverified changes. Rigorous, exhaustive verification is mandatory; it prevents the compounding cost of diagnosing failures later. A task is only complete when the behavioral correctness of the change has been verified and its structural integrity is confirmed within the full project context.
+
+**Strategic Re-evaluation:** If you have attempted to fix a failing implementation more than 3 times without success, you must:
+1. Stop and remind yourself of the original task description.
+2. List your current assumptions and identify which ones might be wrong.
+3. Propose a different architectural approach rather than continuing to patch the current one.
+
+## New Applications
+
+**Goal:** Autonomously implement and deliver a visually appealing, substantially complete, and functional prototype with rich aesthetics.
+
+1. **Understand Requirements:** Analyze the user's request to identify core features, desired user experience (UX), visual aesthetic, application type/platform (web, mobile, desktop, CLI, library, 2D or 3D game), and explicit constraints.
+2. **Plan:** Formulate an internal development plan. For applications requiring visual assets, describe the strategy for sourcing or generating placeholders.
+   - **Styling:** **Prefer Vanilla CSS** for maximum flexibility. **Avoid TailwindCSS** unless explicitly requested.
+   - **Default Tech Stack:**
+     - **Web:** React (TypeScript) or Angular with Vanilla CSS.
+     - **APIs:** Node.js (Express) or Python (FastAPI).
+     - **Games:** HTML/CSS/JS (Three.js for 3D).
+     - **CLIs:** Python or Go.
+3. **Implementation:** Autonomously implement each feature per the plan. When starting, scaffold the application using run_shell_command. For interactive scaffolding tools (like create-react-app, create-vite, or npm create), you MUST use the corresponding non-interactive flag (e.g. '--yes', '-y', or specific template flags) to prevent the environment from hanging waiting for user input. For visual assets, utilize **platform-native primitives** (e.g., stylized shapes, gradients, icons). Never link to external services or assume local paths for assets that have not been created.
+4. **Verify:** Review work against the original request. Fix bugs and deviations. **Build the application and ensure there are no compile errors.**
+
+# Operational Guidelines
+
+## Tone and Style
+
+- **Role:** A senior software engineer and collaborative peer programmer.
+- **High-Signal Output:** Focus exclusively on **intent** and **technical rationale**. Avoid conversational filler, apologies, and mechanical tool-use narration (e.g., "I will now call...").
+- **Concise & Direct:** Adopt a professional, direct, and concise tone suitable for a CLI environment.
+- **Minimal Output:** Aim for fewer than 3 lines of text output (excluding tool use/code generation) per response whenever practical.
+- **No Repetition:** Once you have provided a final synthesis of your work, do not repeat yourself or provide additional summaries. For simple or direct requests, prioritize extreme brevity.
+- **Formatting:** Use GitHub-flavored Markdown. Responses will be rendered in monospace.
+- **Tools vs. Text:** Use tools for actions, text output *only* for communication. Do not add explanatory comments within tool calls.
+- **Handling Inability:** If unable/unwilling to fulfill a request, state so briefly without excessive justification. Offer alternatives if appropriate.
+
+## Security and Safety Rules
+- **Explain Critical Commands:** Before executing commands with run_shell_command that modify the file system, codebase, or system state, you *must* provide a brief explanation of the command's purpose and potential impact.
+- **Security First:** Always apply security best practices. Never introduce code that exposes, logs, or commits secrets, API keys, or other sensitive information.
+
+## Tool Usage
+- **Tool Execution Response Rules:**
+  1. After receiving a tool result, you MUST ALWAYS execute one of the following two actions:
+     a) Call another tool to proceed with the task.
+     b) Provide a user-facing text response explaining the tool output, your analysis, and next steps.
+  2. You MUST NEVER return an empty response with no text and no tool calls.
+- **Post-Edit Response Rules:**
+  1. After an edit tool execution (e.g. replace, write_file), you MUST ALWAYS generate a user-facing text response summarizing:
+     - What changes were made to the file.
+     - Your verification plan or next steps (e.g. running tests).
+  2. You MUST NEVER return an empty response with 0 text tokens after completing an edit.
+- **File Editing Collisions:** Do NOT make multiple calls to the replace tool for the SAME file in a single turn. To make multiple edits to the same file, you MUST perform them sequentially across multiple conversational turns to prevent race conditions and ensure the file state is accurate before each edit.
+- **Command Execution:** Use the run_shell_command tool for running shell commands, remembering the safety rule to explain modifying commands first.
+- **Background Processes:** To run a command in the background, set the ` + "`is_background`" + ` parameter to true. Do NOT use ` + "`&`" + ` to background commands.
+- **Interactive Commands:** Always prefer non-interactive commands (e.g., using 'run once' or 'CI' flags for test runners to avoid persistent watch modes or 'git --no-pager'); commands that wait for user input will hang until they time out.
+- **Confirmation Protocol:** If a tool call is declined or cancelled, respect the decision immediately. Do not re-attempt the action or "negotiate" for the same tool call unless the user explicitly directs you to. Offer an alternative technical path if possible.
+
+# Sandbox
+
+You are running inside an Agent Sandbox: a dedicated, isolated Kubernetes pod. All of your tools and shell commands execute inside this sandbox, not on the user's machine. Your workspace root is the sandbox home directory; it is the only directory that is persisted (via snapshots) across sandbox restarts, so keep all work under it. The sandbox may be recycled between conversation turns after a period of inactivity: files under the home directory will be restored, but processes will not survive, and files outside the home directory may be reset.
+
+# Git Repositories
+
+If the directory you are working in is managed by git:
+- **NEVER** stage or commit your changes, unless you are explicitly instructed to commit.
+- When asked to commit changes, always start by gathering information with ` + "`git status && git diff HEAD && git log -n 3`" + `, then stage only the specific files that were changed or created as part of the task (do not use ` + "`git add .`" + ` or ` + "`git add -A`" + ` unprompted).
+- Always propose a draft commit message. Prefer commit messages that are clear, concise, and focused more on "why" and less on "what".
+- After each commit, confirm that it was successful by running ` + "`git status`" + `.
+- If a commit fails, never attempt to work around the issues without being asked to do so.
+- Never push changes to a remote repository without being asked explicitly by the user.`

--- a/examples/sandboxed-tools/pkg/toolsets/geminicli/shell.go
+++ b/examples/sandboxed-tools/pkg/toolsets/geminicli/shell.go
@@ -1,0 +1,151 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package geminicli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/agent-sandbox/examples/sandboxed-tools/pkg/llm"
+	"sigs.k8s.io/agent-sandbox/examples/sandboxed-tools/pkg/tools"
+)
+
+// ShellToolName matches gemini-cli's shell tool name.
+const ShellToolName = "run_shell_command"
+
+// maxShellOutputSize limits the maximum size of the output of shell commands.
+const maxShellOutputSize = 8 * (1 << 20) // 8 MB
+
+// RunShellCommandTool executes a bash command inside the sandbox, mirroring
+// gemini-cli's run_shell_command tool. Commands run in the sandbox home
+// directory (the persisted workspace) unless dir_path says otherwise.
+//
+// TODO: gemini-cli's shell tool also reports "Background PIDs" for any
+// processes left running and the process-group PGID (so the model can
+// `kill -- -PGID`), and truncates very large command output. We only report
+// the background PID and log file from the is_background path.
+//
+// TODO: gemini-cli's schema also has a `delay_ms` parameter (how long to wait
+// for initial output after starting a background process; ours is fixed at
+// 1s in backgroundScript) and, in parallel-tool-call configurations, a
+// `wait_for_previous` parameter (our harness executes tool calls
+// sequentially, so it is not needed yet).
+type RunShellCommandTool struct {
+	// Command is the exact bash command to execute.
+	Command string `json:"command"`
+	// Description is a brief user-facing description of the command.
+	Description string `json:"description,omitempty"`
+	// DirPath is the directory to run the command in, relative to the
+	// workspace root (the sandbox home directory).
+	DirPath string `json:"dir_path,omitempty"`
+	// IsBackground runs the command as a detached background process.
+	IsBackground bool `json:"is_background,omitempty"`
+}
+
+func (t *RunShellCommandTool) Schema() llm.Tool {
+	return llm.Tool{
+		Type: "function",
+		Function: llm.ToolFunction{
+			Name: ShellToolName,
+			Description: "This tool executes a given shell command as `bash -c <command>` inside the sandbox. To run a command in the background, set the `is_background` parameter to true; do NOT use `&` to background commands yourself.\n\n" +
+				"The following information is returned:\n\n" +
+				"Output: Combined stdout/stderr. Can be `(empty)`.\n" +
+				"Exit Code: Only included if non-zero (command failed).",
+			Parameters: objectSchema(map[string]any{
+				"command": map[string]any{
+					"type":        "string",
+					"description": "Exact bash command to execute as `bash -c <command>`",
+				},
+				"description": map[string]any{
+					"type":        "string",
+					"description": "Brief description of the command for the user. Be specific and concise. Ideally a single sentence. Can be up to 3 sentences for clarity. No line breaks.",
+				},
+				"dir_path": map[string]any{
+					"type":        "string",
+					"description": "(OPTIONAL) The path of the directory to run the command in. If not provided, the workspace root directory is used. Must already exist.",
+				},
+				"is_background": map[string]any{
+					"type":        "boolean",
+					"description": "Set to true if this command should be run in the background (e.g. for long-running servers or watchers). The command will be started, allowed to run for a brief moment to check for immediate errors, and then left running in the background.",
+				},
+			}, "command"),
+		},
+	}
+}
+
+// foregroundScript runs the model's command ($2) in the requested directory
+// ($1, defaulting to the sandbox home). It is executed as
+// `bash -c <script> <name> <dir> <command>`.
+const foregroundScript = `cd -- "${HOME:-/}" || exit 1
+if [ -n "$1" ]; then cd -- "$1" || exit 1; fi
+exec bash -c "$2"`
+
+// backgroundScript starts the model's command detached from the exec session
+// (so it survives the kubernetes exec connection closing), waits briefly, and
+// reports the PID plus any initial output.
+const backgroundScript = `cd -- "${HOME:-/}" || exit 1
+if [ -n "$1" ]; then cd -- "$1" || exit 1; fi
+logfile="$(mktemp /tmp/shell-bg-XXXXXX.log)"
+setsid bash -c "$2" </dev/null >"$logfile" 2>&1 &
+pid=$!
+sleep 1
+echo "Started background process with PID ${pid}. Output is being logged to ${logfile}."
+echo "--- initial output ---"
+tail -c 2000 -- "$logfile"`
+
+func (t *RunShellCommandTool) Run(ctx context.Context, sandbox tools.Sandbox) (llm.Message, error) {
+	log := klog.FromContext(ctx)
+
+	if t.Command == "" {
+		return llm.Message{}, errors.New("command is required")
+	}
+
+	// Don't log command because it may contain secrets.
+	log.Info("executing shell command in sandbox", "background", t.IsBackground)
+
+	script := foregroundScript
+	if t.IsBackground {
+		script = backgroundScript
+	}
+
+	// The shell tool reports combined stdout/stderr, so stream both into one
+	// buffer; syncWriter serializes the two streams.
+	combined := tools.NewLimitedWriter(maxShellOutputSize)
+	res, err := sandbox.ExecCommand(ctx, tools.ExecCommandOptions{
+		Command: []string{"bash", "-c", script, ShellToolName, t.DirPath, t.Command},
+		Stdout:  combined,
+		Stderr:  combined,
+	})
+	if err != nil {
+		return llm.Message{}, err
+	}
+
+	output := combined.String()
+	if strings.TrimSpace(output) == "" {
+		output = "(empty)"
+	}
+
+	if combined.Truncated() {
+		output += fmt.Sprintf("\n[Output truncated at %d bytes]", combined.Len())
+	}
+	content := "Output: " + output
+	if res.ExitCode != 0 {
+		content += fmt.Sprintf("\nExit Code: %d", res.ExitCode)
+	}
+	return llm.Message{Content: &content}, nil
+}

--- a/examples/sandboxed-tools/pkg/toolsets/geminicli/toolbox/glob.go
+++ b/examples/sandboxed-tools/pkg/toolsets/geminicli/toolbox/glob.go
@@ -1,0 +1,121 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package toolbox
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"path/filepath"
+	"slices"
+	"strings"
+	"time"
+)
+
+// GlobParams are the arguments of the glob tool.
+type GlobParams struct {
+	// Pattern is the glob pattern to match, e.g. "src/**/*.go".
+	Pattern string `json:"pattern"`
+	// DirPath is the directory to search in (defaults to the workspace root).
+	DirPath string `json:"dir_path,omitempty"`
+	// CaseSensitive makes matching case-sensitive (default false).
+	CaseSensitive bool `json:"case_sensitive,omitempty"`
+}
+
+// alwaysSkippedDirs are directories never traversed by glob/grep/read_many_files:
+// they are effectively never what the model is looking for, and walking them
+// is slow and noisy. This stands in for gemini-cli's gitignore handling.
+//
+// TODO: gemini-cli respects .gitignore and .geminiignore when searching and
+// listing (with respect_git_ignore / respect_gemini_ignore / no_ignore /
+// file_filtering_options parameters on glob, grep_search, list_directory,
+// and read_many_files). Parsing those ignore files here would tighten
+// results in real repositories; the parameters are omitted from our schemas
+// until the behavior exists.
+var alwaysSkippedDirs = map[string]bool{
+	".git":         true,
+	"node_modules": true,
+}
+
+// glob mirrors gemini-cli's glob tool: matching file paths, newest first.
+func glob(root string, params GlobParams) (string, error) {
+	if params.Pattern == "" {
+		return "", errors.New("pattern is required")
+	}
+	dir := resolvePath(root, params.DirPath)
+
+	type match struct {
+		path    string
+		modTime time.Time
+	}
+	var matches []match
+
+	matcher, err := NewGlobMatcher(params.Pattern, params.CaseSensitive)
+	if err != nil {
+		return "", fmt.Errorf("invalid glob pattern %q: %w", params.Pattern, err)
+	}
+
+	if err := filepath.WalkDir(dir, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			// Report unreadable roots, skip unreadable subtrees.
+			if p == dir {
+				return err
+			}
+			return nil
+		}
+		if d.IsDir() {
+			if p != dir && alwaysSkippedDirs[d.Name()] {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		rel, err := filepath.Rel(dir, p)
+		if err != nil {
+			return nil
+		}
+		if !matcher.Matches(filepath.ToSlash(rel)) {
+			return nil
+		}
+		m := match{path: p}
+		if info, err := d.Info(); err == nil {
+			m.modTime = info.ModTime()
+		}
+		matches = append(matches, m)
+		return nil
+	}); err != nil {
+		return "", fmt.Errorf("failed to search %s: %w", dir, err)
+	}
+
+	if len(matches) == 0 {
+		return fmt.Sprintf("No files found matching pattern %q within %s.", params.Pattern, dir), nil
+	}
+
+	slices.SortFunc(matches, func(a, b match) int {
+		if !a.modTime.Equal(b.modTime) {
+			if a.modTime.After(b.modTime) {
+				return -1
+			}
+			return 1
+		}
+		return strings.Compare(a.path, b.path)
+	})
+
+	var paths []string
+	for _, m := range matches {
+		paths = append(paths, m.path)
+	}
+	return fmt.Sprintf("Found %d file(s) matching %q within %s, sorted by modification time (newest first):\n%s",
+		len(matches), params.Pattern, dir, strings.Join(paths, "\n")), nil
+}

--- a/examples/sandboxed-tools/pkg/toolsets/geminicli/toolbox/glob_match.go
+++ b/examples/sandboxed-tools/pkg/toolsets/geminicli/toolbox/glob_match.go
@@ -1,0 +1,162 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package toolbox
+
+import (
+	"fmt"
+	"path"
+	"strings"
+)
+
+// GlobMatcher matches a single glob pattern, and pre-computes the expanded
+// glob patterns to avoid re-expanding on every match.
+type GlobMatcher struct {
+	pattern       string
+	caseSensitive bool
+	sections      []string
+}
+
+// NewGlobMatcher creates a new GlobMatcher.
+// In addition to the path.Match syntax within a segment
+// ('*', '?', '[...]'), it supports '**' (matches zero or more path segments)
+// and brace alternation ('{a,b}'), which gemini-cli's tool descriptions
+// advertise (e.g. "src/**/*.{ts,tsx}").
+func NewGlobMatcher(pattern string, caseSensitive bool) (*GlobMatcher, error) {
+	m := &GlobMatcher{
+		pattern:       pattern,
+		caseSensitive: caseSensitive,
+	}
+
+	if !caseSensitive {
+		pattern = strings.ToLower(pattern)
+	}
+
+	m.sections = expandBraces(pattern)
+
+	// Verify the segments
+	for _, expanded := range m.sections {
+		for segment := range strings.SplitSeq(expanded, "/") {
+			if _, err := path.Match(segment, "test"); err != nil {
+				return nil, fmt.Errorf("path.Match %q failed: %v", segment, err)
+			}
+		}
+	}
+
+	return m, nil
+}
+
+// Matches checks whether the slash-separated relative path p matches the
+// glob pattern.
+func (m *GlobMatcher) Matches(p string) bool {
+	if !m.caseSensitive {
+		p = strings.ToLower(p)
+	}
+
+	// Split the path into segments and compare with the pattern segments
+	for _, expanded := range m.sections {
+		if matchSegments(strings.Split(expanded, "/"), strings.Split(p, "/")) {
+			return true
+		}
+	}
+	return false
+}
+
+// MatchAnyGlob reports whether p matches any of the given matchers.
+func MatchAnyGlob(matchers []*GlobMatcher, p string) bool {
+	for _, m := range matchers {
+		if m.Matches(p) {
+			return true
+		}
+	}
+	return false
+}
+
+func matchSegments(pattern []string, segments []string) bool {
+	if len(pattern) == 0 {
+		return len(segments) == 0
+	}
+	if pattern[0] == "**" {
+		// '**' matches zero or more whole path segments.
+		for i := 0; i <= len(segments); i++ {
+			if matchSegments(pattern[1:], segments[i:]) {
+				return true
+			}
+		}
+		return false
+	}
+	if len(segments) == 0 {
+		return false
+	}
+	ok, err := path.Match(pattern[0], segments[0])
+	if err != nil {
+		// This should not happen - pattern should have been checked above
+		panic(fmt.Sprintf("path.Match %q failed: %v", pattern[0], err))
+	}
+	if !ok {
+		return false
+	}
+	return matchSegments(pattern[1:], segments[1:])
+}
+
+// expandBraces expands the first brace alternation in the pattern and recurses,
+// turning "a.{b,c}" into ["a.b", "a.c"]. Patterns without braces are returned
+// unchanged. Nested braces are supported; unbalanced braces are left literal.
+func expandBraces(pattern string) []string {
+	open := strings.IndexByte(pattern, '{')
+	if open < 0 {
+		return []string{pattern}
+	}
+
+	depth := 0
+	for i := open; i < len(pattern); i++ {
+		switch pattern[i] {
+		case '{':
+			depth++
+		case '}':
+			depth--
+			if depth == 0 {
+				var out []string
+				for _, alt := range splitAlternatives(pattern[open+1 : i]) {
+					out = append(out, expandBraces(pattern[:open]+alt+pattern[i+1:])...)
+				}
+				return out
+			}
+		}
+	}
+	// Unbalanced '{': treat as a literal.
+	return []string{pattern}
+}
+
+// splitAlternatives splits a brace body on top-level commas ("b,{c,d}e" =>
+// ["b", "{c,d}e"]).
+func splitAlternatives(body string) []string {
+	var alternatives []string
+	depth := 0
+	start := 0
+	for i := range len(body) {
+		switch body[i] {
+		case '{':
+			depth++
+		case '}':
+			depth--
+		case ',':
+			if depth == 0 {
+				alternatives = append(alternatives, body[start:i])
+				start = i + 1
+			}
+		}
+	}
+	return append(alternatives, body[start:])
+}

--- a/examples/sandboxed-tools/pkg/toolsets/geminicli/toolbox/glob_match_test.go
+++ b/examples/sandboxed-tools/pkg/toolsets/geminicli/toolbox/glob_match_test.go
@@ -1,0 +1,57 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package toolbox
+
+import "testing"
+
+func TestMatchGlob(t *testing.T) {
+	tests := []struct {
+		pattern       string
+		path          string
+		caseSensitive bool
+		want          bool
+	}{
+		{pattern: "*.md", path: "README.md", want: true},
+		{pattern: "*.md", path: "docs/README.md", want: false},
+		{pattern: "**/*.md", path: "docs/README.md", want: true},
+		{pattern: "**/*.md", path: "README.md", want: true},
+		{pattern: "**/*.md", path: "a/b/c/README.md", want: true},
+		{pattern: "src/**/*.go", path: "src/pkg/deep/main.go", want: true},
+		{pattern: "src/**/*.go", path: "other/pkg/main.go", want: false},
+		{pattern: "src/**", path: "src/anything/at/all.txt", want: true},
+		{pattern: "src/**", path: "srcx/file.txt", want: false},
+		{pattern: "*.{ts,tsx}", path: "app.tsx", want: true},
+		{pattern: "*.{ts,tsx}", path: "app.ts", want: true},
+		{pattern: "*.{ts,tsx}", path: "app.go", want: false},
+		{pattern: "file?.txt", path: "file1.txt", want: true},
+		{pattern: "file?.txt", path: "file12.txt", want: false},
+		{pattern: "README.MD", path: "readme.md", want: true},
+		{pattern: "README.MD", path: "readme.md", caseSensitive: true, want: false},
+		{pattern: "a/{b,c/d}/e.txt", path: "a/c/d/e.txt", want: true},
+		{pattern: "a/{b,c/d}/e.txt", path: "a/b/e.txt", want: true},
+		// Unbalanced braces are treated as literals.
+		{pattern: "a{b.txt", path: "a{b.txt", want: true},
+	}
+	for _, tc := range tests {
+		m, err := NewGlobMatcher(tc.pattern, tc.caseSensitive)
+		if err != nil {
+			t.Errorf("NewGlobMatcher(%q, caseSensitive=%v) failed: %v", tc.pattern, tc.caseSensitive, err)
+			continue
+		}
+		if got := m.Matches(tc.path); got != tc.want {
+			t.Errorf("matchGlob(%q, %q, caseSensitive=%v) = %v, want %v", tc.pattern, tc.path, tc.caseSensitive, got, tc.want)
+		}
+	}
+}

--- a/examples/sandboxed-tools/pkg/toolsets/geminicli/toolbox/grep.go
+++ b/examples/sandboxed-tools/pkg/toolsets/geminicli/toolbox/grep.go
@@ -1,0 +1,310 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package toolbox
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"strings"
+
+	"sigs.k8s.io/agent-sandbox/examples/sandboxed-tools/pkg/tools"
+)
+
+// GrepParams are the arguments of the grep_search tool.
+type GrepParams struct {
+	// Pattern is the regular expression to search for.
+	Pattern string `json:"pattern"`
+	// DirPath is the directory (or single file) to search (defaults to the
+	// workspace root). Directories are searched recursively.
+	DirPath string `json:"dir_path,omitempty"`
+	// IncludePattern is a glob restricting which files are searched.
+	// Ignored if DirPath is a single file.
+	IncludePattern string `json:"include_pattern,omitempty"`
+	// ExcludePattern is a regex; matching lines are omitted from the results.
+	// Ignored if DirPath is a single file.
+	ExcludePattern string `json:"exclude_pattern,omitempty"`
+	// NamesOnly returns only the matching file paths.
+	NamesOnly bool `json:"names_only,omitempty"`
+	// CaseSensitive makes the search case-sensitive (default false).
+	CaseSensitive bool `json:"case_sensitive,omitempty"`
+	// FixedStrings treats Pattern as a literal string.
+	FixedStrings bool `json:"fixed_strings,omitempty"`
+	// Context requests this many lines of context around each match (-C).
+	Context int `json:"context,omitempty"`
+	// After requests this many lines after each match (-A).
+	After int `json:"after,omitempty"`
+	// Before requests this many lines before each match (-B).
+	Before int `json:"before,omitempty"`
+	// MaxMatchesPerFile bounds matches per file.
+	MaxMatchesPerFile int `json:"max_matches_per_file,omitempty"`
+	// TotalMaxMatches bounds total matches (default 100).
+	TotalMaxMatches int `json:"total_max_matches,omitempty"`
+}
+
+// defaultTotalMaxMatches mirrors gemini-cli's default cap of 100 matches.
+const defaultTotalMaxMatches = 100
+
+// maxGrepFileSize bounds the size of files we search.
+const maxGrepFileSize = 10 * 1024 * 1024
+
+// maxGrepResponseSize bounds the total response size.
+const maxGrepResponseSize = 4 * 1024 * 1024
+
+// grepLine is one output line: either a match or surrounding context.
+type grepLine struct {
+	number    int
+	text      string
+	isContext bool
+}
+
+// grep mirrors gemini-cli's grep_search tool using Go's regexp engine.
+func grep(ctx context.Context, root string, params GrepParams) (string, error) {
+	if params.Pattern == "" {
+		return "", errors.New("pattern is required")
+	}
+
+	expr := params.Pattern
+	if params.FixedStrings {
+		expr = regexp.QuoteMeta(expr)
+	}
+	if !params.CaseSensitive {
+		expr = "(?i)" + expr
+	}
+	re, err := regexp.Compile(expr)
+	if err != nil {
+		return "", fmt.Errorf("invalid regular expression pattern %q: %w", params.Pattern, err)
+	}
+
+	var exclude *regexp.Regexp
+	if params.ExcludePattern != "" {
+		exclude, err = regexp.Compile(params.ExcludePattern)
+		if err != nil {
+			return "", fmt.Errorf("invalid exclude_pattern %q: %w", params.ExcludePattern, err)
+		}
+	}
+
+	totalMax := params.TotalMaxMatches
+	if totalMax <= 0 {
+		totalMax = defaultTotalMaxMatches
+	}
+	// cap total max matches at 1024 to avoid overwhelming the model
+	if totalMax > 1024 {
+		return "", errors.New("total_max_matches too large: 1024 is the maximum allowed")
+	}
+
+	before := max(params.Before, params.Context)
+	after := max(params.After, params.Context)
+
+	// cap before and after at 1024 to avoid overwhelming the model
+	if before > 1024 {
+		return "", errors.New("before context too large: 1024 is the maximum allowed")
+	}
+	if after > 1024 {
+		return "", errors.New("after context too large: 1024 is the maximum allowed")
+	}
+
+	target := resolvePath(root, params.DirPath)
+	info, err := os.Stat(target)
+	if err != nil {
+		return "", fmt.Errorf("failed to search %s: %w", target, err)
+	}
+
+	var globMatcher *GlobMatcher
+	if params.IncludePattern != "" {
+		globMatcher, err = NewGlobMatcher(params.IncludePattern, true)
+		if err != nil {
+			return "", fmt.Errorf("invalid include_pattern %q: %w", params.IncludePattern, err)
+		}
+	}
+
+	// Collect the files to search, in a deterministic order.
+	var files []string
+	if !info.IsDir() {
+		// If the target is a single file, just search that file.
+		// We don't apply includePattern etc
+		files = append(files, target)
+	} else {
+		walkErr := filepath.WalkDir(target, func(p string, d fs.DirEntry, err error) error {
+			if err != nil {
+				if p == target {
+					return err
+				}
+				return nil
+			}
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			if d.IsDir() {
+				if p != target && alwaysSkippedDirs[d.Name()] {
+					return filepath.SkipDir
+				}
+				return nil
+			}
+			if params.IncludePattern != "" {
+				rel, err := filepath.Rel(target, p)
+				if err != nil {
+					// This should not happen, so if it does just bail out.
+					return fmt.Errorf("failed to compute relative path for %s: %w", p, err)
+				}
+				// Like ripgrep's -g, a basename pattern such as "*.go"
+				// matches at any depth.
+				if !globMatcher.Matches(filepath.ToSlash(rel)) &&
+					!globMatcher.Matches(d.Name()) {
+					return nil
+				}
+			}
+			files = append(files, p)
+			return nil
+		})
+		if walkErr != nil {
+			return "", fmt.Errorf("failed to search %s: %w", target, walkErr)
+		}
+		slices.Sort(files)
+	}
+
+	matchesByFile := make(map[string][]grepLine)
+	var matchedFiles []string
+	totalMatches := 0
+	truncated := false
+
+fileLoop:
+	for _, file := range files {
+		if err := ctx.Err(); err != nil {
+			return "", err
+		}
+
+		if info, err := os.Stat(file); err != nil || info.Size() > maxGrepFileSize {
+			continue
+		}
+		data, err := os.ReadFile(file)
+		if err != nil || isBinary(data) {
+			continue
+		}
+
+		lines := strings.Split(string(data), "\n")
+		matchesInFile := 0
+		var kept []grepLine
+		keptLines := make(map[int]bool)
+
+		for i, line := range lines {
+			if !re.MatchString(line) {
+				continue
+			}
+			if exclude != nil && exclude.MatchString(line) {
+				continue
+			}
+			if params.MaxMatchesPerFile > 0 && matchesInFile >= params.MaxMatchesPerFile {
+				break
+			}
+
+			// Insert any context lines before the match that we haven't
+			// already emitted.
+			for j := max(0, i-before); j < i; j++ {
+				if !keptLines[j] {
+					kept = append(kept, grepLine{number: j + 1, text: lines[j], isContext: true})
+					keptLines[j] = true
+				}
+			}
+			if keptLines[i] {
+				// Previously emitted as context; upgrade it to a match.
+				for k := range kept {
+					if kept[k].number == i+1 {
+						kept[k].isContext = false
+					}
+				}
+			} else {
+				kept = append(kept, grepLine{number: i + 1, text: line})
+				keptLines[i] = true
+			}
+			for j := i + 1; j <= min(len(lines)-1, i+after); j++ {
+				if !keptLines[j] {
+					kept = append(kept, grepLine{number: j + 1, text: lines[j], isContext: true})
+					keptLines[j] = true
+				}
+			}
+
+			matchesInFile++
+			totalMatches++
+			if totalMatches >= totalMax {
+				truncated = true
+				if len(kept) > 0 {
+					matchesByFile[file] = kept
+					matchedFiles = append(matchedFiles, file)
+				}
+				break fileLoop
+			}
+		}
+
+		if len(kept) > 0 {
+			matchesByFile[file] = kept
+			matchedFiles = append(matchedFiles, file)
+		}
+	}
+
+	searchLocation := fmt.Sprintf("in %s", target)
+	filterSuffix := ""
+	if params.IncludePattern != "" {
+		filterSuffix = fmt.Sprintf(" (filter: %q)", params.IncludePattern)
+	}
+
+	if totalMatches == 0 {
+		return fmt.Sprintf("No matches found for pattern %q %s%s.", params.Pattern, searchLocation, filterSuffix), nil
+	}
+
+	truncationSuffix := ""
+	if truncated {
+		truncationSuffix = fmt.Sprintf(" (results limited to %d matches for performance)", totalMax)
+	}
+
+	if params.NamesOnly {
+		return fmt.Sprintf("Found %d files with matches for pattern %q %s%s%s:\n%s",
+			len(matchedFiles), params.Pattern, searchLocation, filterSuffix, truncationSuffix,
+			strings.Join(matchedFiles, "\n")), nil
+	}
+
+	matchTerm := "matches"
+	if totalMatches == 1 {
+		matchTerm = "match"
+	}
+	out := tools.NewLimitedWriter(maxGrepResponseSize)
+
+	fmt.Fprintf(out, "Found %d %s for pattern %q %s%s%s:\n---\n",
+		totalMatches, matchTerm, params.Pattern, searchLocation, filterSuffix, truncationSuffix)
+	for _, file := range matchedFiles {
+		fmt.Fprintf(out, "File: %s\n", file)
+		for _, line := range matchesByFile[file] {
+			separator := ":"
+			if line.isContext {
+				separator = "-"
+			}
+			fmt.Fprintf(out, "L%d%s %s\n", line.number, separator, truncateLine(strings.TrimRight(line.text, " \t\r")))
+		}
+		fmt.Fprintf(out, "---\n")
+	}
+
+	output := out.String()
+
+	if out.Truncated() {
+		output += fmt.Sprintf("\n[Output truncated at %d bytes]", out.Len())
+	}
+
+	return output, nil
+}

--- a/examples/sandboxed-tools/pkg/toolsets/geminicli/toolbox/list_directory.go
+++ b/examples/sandboxed-tools/pkg/toolsets/geminicli/toolbox/list_directory.go
@@ -1,0 +1,97 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package toolbox
+
+import (
+	"fmt"
+	"os"
+	"slices"
+	"strings"
+)
+
+// ListDirectoryParams are the arguments of the list_directory tool.
+type ListDirectoryParams struct {
+	// DirPath is the directory to list.
+	DirPath string `json:"dir_path"`
+	// Ignore holds glob patterns for entries to omit from the listing.
+	Ignore []string `json:"ignore,omitempty"`
+}
+
+// listDirectory mirrors gemini-cli's list_directory output: directories
+// first (marked [DIR]), then files with sizes.
+func listDirectory(root string, params ListDirectoryParams) (string, error) {
+	dir := resolvePath(root, params.DirPath)
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return "", fmt.Errorf("failed to list directory: %w", err)
+	}
+
+	type item struct {
+		name  string
+		isDir bool
+		size  int64
+	}
+
+	var ignoreMatchers []*GlobMatcher
+	for _, pattern := range params.Ignore {
+		m, err := NewGlobMatcher(pattern, false)
+		if err != nil {
+			return "", fmt.Errorf("invalid ignore_pattern %q: %w", pattern, err)
+		}
+		ignoreMatchers = append(ignoreMatchers, m)
+	}
+
+	var items []item
+	ignoredCount := 0
+	for _, entry := range entries {
+		if MatchAnyGlob(ignoreMatchers, entry.Name()) {
+			ignoredCount++
+			continue
+		}
+		it := item{name: entry.Name(), isDir: entry.IsDir()}
+		if !it.isDir {
+			if info, err := entry.Info(); err == nil {
+				it.size = info.Size()
+			}
+		}
+		items = append(items, it)
+	}
+
+	slices.SortFunc(items, func(a, b item) int {
+		if a.isDir != b.isDir {
+			if a.isDir {
+				return -1
+			}
+			return 1
+		}
+		return strings.Compare(a.name, b.name)
+	})
+
+	var lines []string
+	for _, it := range items {
+		if it.isDir {
+			lines = append(lines, fmt.Sprintf("[DIR] %s", it.name))
+		} else {
+			lines = append(lines, fmt.Sprintf("%s (%d bytes)", it.name, it.size))
+		}
+	}
+
+	result := fmt.Sprintf("Directory listing for %s:\n%s", dir, strings.Join(lines, "\n"))
+	if ignoredCount > 0 {
+		result += fmt.Sprintf("\n\n(%d ignored)", ignoredCount)
+	}
+	return result, nil
+}

--- a/examples/sandboxed-tools/pkg/toolsets/geminicli/toolbox/read_file.go
+++ b/examples/sandboxed-tools/pkg/toolsets/geminicli/toolbox/read_file.go
@@ -1,0 +1,101 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package toolbox
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+)
+
+// ReadFileParams are the arguments of the read_file tool.
+type ReadFileParams struct {
+	// FilePath is the file to read.
+	FilePath string `json:"file_path"`
+	// StartLine is the optional 1-based first line to read.
+	StartLine int `json:"start_line,omitempty"`
+	// EndLine is the optional 1-based last line to read (inclusive).
+	EndLine int `json:"end_line,omitempty"`
+}
+
+// maxLinesPerRead mirrors gemini-cli's DEFAULT_MAX_LINES_TEXT_FILE.
+const maxLinesPerRead = 2000
+
+// maxReadFileSize bounds how much of a file we are willing to load.
+const maxReadFileSize = 20 * 1024 * 1024
+
+// readFile mirrors gemini-cli's read_file: text content with optional line
+// ranges, truncated with an explanatory header when the file is large.
+func readFile(root string, params ReadFileParams) (string, error) {
+	if params.FilePath == "" {
+		return "", errors.New("file_path is required")
+	}
+	p := resolvePath(root, params.FilePath)
+
+	info, err := os.Stat(p)
+	if err != nil {
+		return "", fmt.Errorf("failed to read file: %w", err)
+	}
+	if info.IsDir() {
+		return "", fmt.Errorf("path is a directory, not a file: %s (use list_directory instead)", p)
+	}
+	if info.Size() > maxReadFileSize {
+		return "", fmt.Errorf("file %s is too large to read (%d bytes)", p, info.Size())
+	}
+
+	data, err := os.ReadFile(p)
+	if err != nil {
+		return "", fmt.Errorf("failed to read file: %w", err)
+	}
+	if isBinary(data) {
+		return "", fmt.Errorf("cannot display content of binary file: %s", p)
+	}
+
+	lines := strings.Split(string(data), "\n")
+	totalLines := len(lines)
+
+	start := 1
+	if params.StartLine > 0 {
+		start = params.StartLine
+	}
+	if start > totalLines {
+		return "", fmt.Errorf("start_line %d is beyond the end of the file (%d lines)", start, totalLines)
+	}
+	end := min(start+maxLinesPerRead-1, totalLines)
+	if params.EndLine > 0 {
+		end = min(params.EndLine, end)
+	}
+	if end < start {
+		return "", fmt.Errorf("end_line %d is before start_line %d", params.EndLine, start)
+	}
+
+	selected := lines[start-1 : end]
+	for i, line := range selected {
+		selected[i] = truncateLine(line)
+	}
+	content := strings.Join(selected, "\n")
+
+	if start > 1 || end < totalLines {
+		return fmt.Sprintf(`
+IMPORTANT: The file content has been truncated.
+Status: Showing lines %d-%d of %d total lines.
+Action: To read more of the file, you can use the 'start_line' and 'end_line' parameters in a subsequent 'read_file' call. For example, to read the next section of the file, use start_line: %d.
+
+--- FILE CONTENT (truncated) ---
+%s`, start, end, totalLines, end+1, content), nil
+	}
+	return content, nil
+}

--- a/examples/sandboxed-tools/pkg/toolsets/geminicli/toolbox/read_many_files.go
+++ b/examples/sandboxed-tools/pkg/toolsets/geminicli/toolbox/read_many_files.go
@@ -1,0 +1,194 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package toolbox
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+)
+
+// ReadManyFilesParams are the arguments of the read_many_files tool.
+type ReadManyFilesParams struct {
+	// Include holds glob patterns or paths to read.
+	Include []string `json:"include"`
+	// Exclude holds glob patterns to skip (added to the default excludes).
+	Exclude []string `json:"exclude,omitempty"`
+	// Recursive is accepted for schema compatibility; recursion is controlled
+	// by '**' in the glob patterns.
+	Recursive *bool `json:"recursive,omitempty"`
+	// UseDefaultExcludes toggles the built-in exclude list (default true).
+	// Note that we always skip alwaysSkippedDirs
+	UseDefaultExcludes *bool `json:"useDefaultExcludes,omitempty"`
+}
+
+// defaultExcludePatterns is a trimmed-down version of gemini-cli's default
+// exclude list, covering the directories and file types that most often
+// pollute bulk reads.
+var defaultExcludePatterns = []string{
+	"**/node_modules/**",
+	"**/.git/**",
+	"**/dist/**",
+	"**/build/**",
+	"**/coverage/**",
+	"**/__pycache__/**",
+	"**/*.min.js",
+	"**/*.min.css",
+	"**/.DS_Store",
+}
+
+// maxReadManyFileSize bounds each individual file included in the output.
+const maxReadManyFileSize = 1024 * 1024
+
+// maxReadManyTotalSize bounds the total output size.
+const maxReadManyTotalSize = 8 * 1024 * 1024
+
+// readManyFiles mirrors gemini-cli's read_many_files: concatenates the
+// content of every text file matching the include patterns.
+//
+// TODO: gemini-cli also includes image/audio/PDF files as base64 parts when
+// they are explicitly named in 'include'; we skip all binary files (they are
+// listed in the "Skipped" section of the result instead).
+func readManyFiles(ctx context.Context, root string, params ReadManyFilesParams) (string, error) {
+	if len(params.Include) == 0 {
+		return "", errors.New("include is required and must contain at least one pattern")
+	}
+
+	// Normalize include entries: a directory path means "everything under it".
+	var includes []string
+	for _, entry := range params.Include {
+		// Note this logic doesn't handle . and ./docs well, but we want to be compatible with gemini-cli
+		entry = filepath.ToSlash(strings.TrimSuffix(entry, "/"))
+		if entry == "" {
+			continue
+		}
+		if info, err := os.Stat(resolvePath(root, entry)); err == nil && info.IsDir() {
+			entry = entry + "/**"
+		}
+		includes = append(includes, entry)
+	}
+
+	excludes := slices.Clone(params.Exclude)
+	if params.UseDefaultExcludes == nil || *params.UseDefaultExcludes {
+		excludes = append(excludes, defaultExcludePatterns...)
+	}
+	var includeMatchers []*GlobMatcher
+	for _, pattern := range includes {
+		m, err := NewGlobMatcher(pattern, false)
+		if err != nil {
+			return "", fmt.Errorf("invalid include_pattern %q: %w", pattern, err)
+		}
+		includeMatchers = append(includeMatchers, m)
+	}
+	var excludeMatchers []*GlobMatcher
+	for _, pattern := range excludes {
+		m, err := NewGlobMatcher(pattern, false)
+		if err != nil {
+			return "", fmt.Errorf("invalid exclude_pattern %q: %w", pattern, err)
+		}
+		excludeMatchers = append(excludeMatchers, m)
+	}
+
+	var selected []string
+	var skipped []string
+	err := filepath.WalkDir(root, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			if p == root {
+				return err
+			}
+			return nil
+		}
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		if d.IsDir() {
+			if p != root && alwaysSkippedDirs[d.Name()] {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		rel, err := filepath.Rel(root, p)
+		if err != nil {
+			// This should not happen, so if it does just bail out.
+			return fmt.Errorf("failed to compute relative path for %s: %w", p, err)
+		}
+		relSlash := filepath.ToSlash(rel)
+		if !MatchAnyGlob(includeMatchers, relSlash) {
+			return nil
+		}
+		if MatchAnyGlob(excludeMatchers, relSlash) {
+			return nil
+		}
+		selected = append(selected, p)
+		return nil
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to search %s: %w", root, err)
+	}
+	slices.Sort(selected)
+
+	var sb strings.Builder
+	readCount := 0
+	for _, p := range selected {
+		if sb.Len() >= maxReadManyTotalSize {
+			skipped = append(skipped, fmt.Sprintf("%s (total output size limit reached)", p))
+			continue
+		}
+		info, err := os.Stat(p)
+		if err != nil {
+			skipped = append(skipped, fmt.Sprintf("%s (%v)", p, err))
+			continue
+		}
+		if info.Size() > maxReadManyFileSize {
+			skipped = append(skipped, fmt.Sprintf("%s (file too large: %d bytes)", p, info.Size()))
+			continue
+		}
+		data, err := os.ReadFile(p)
+		if err != nil {
+			skipped = append(skipped, fmt.Sprintf("%s (%v)", p, err))
+			continue
+		}
+		if isBinary(data) {
+			skipped = append(skipped, fmt.Sprintf("%s (binary file)", p))
+			continue
+		}
+
+		estimatedAdd := len(data) + len(p) + 32 //rough estimate
+		if sb.Len()+estimatedAdd > maxReadManyTotalSize {
+			skipped = append(skipped, fmt.Sprintf("%s (total output size limit reached)", p))
+			continue
+		}
+
+		fmt.Fprintf(&sb, "--- %s ---\n\n%s\n\n", p, string(data))
+		readCount++
+	}
+
+	if readCount == 0 && len(skipped) == 0 {
+		return "No files matching the criteria were found.", nil
+	}
+
+	// Note: this might result in more than the maxReadManyTotalSize output,
+	// but we are mirroring gemini-cli behaviour.
+	sb.WriteString("--- End of content ---")
+	if len(skipped) > 0 {
+		fmt.Fprintf(&sb, "\n\nSkipped %d file(s):\n%s", len(skipped), strings.Join(skipped, "\n"))
+	}
+	return sb.String(), nil
+}

--- a/examples/sandboxed-tools/pkg/toolsets/geminicli/toolbox/replace.go
+++ b/examples/sandboxed-tools/pkg/toolsets/geminicli/toolbox/replace.go
@@ -1,0 +1,90 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package toolbox
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+)
+
+// ReplaceParams are the arguments of the replace (edit) tool.
+type ReplaceParams struct {
+	// FilePath is the file to modify.
+	FilePath string `json:"file_path"`
+	// Instruction describes the intent of the change. It is not used by the
+	// implementation, but requiring it (as gemini-cli does) improves edit
+	// quality.
+	Instruction string `json:"instruction,omitempty"`
+	// OldString is the exact literal text to replace. Empty creates a new file.
+	OldString string `json:"old_string"`
+	// NewString is the exact literal replacement text.
+	NewString string `json:"new_string"`
+	// AllowMultiple permits replacing every occurrence of OldString.
+	AllowMultiple bool `json:"allow_multiple,omitempty"`
+}
+
+// replace mirrors gemini-cli's replace tool: an exact-literal-string edit
+// that fails loudly when the target text is missing or ambiguous.
+func replace(root string, params ReplaceParams) (string, error) {
+	if params.FilePath == "" {
+		return "", errors.New("file_path is required")
+	}
+	p := resolvePath(root, params.FilePath)
+
+	// As in gemini-cli, an empty old_string means "create this file".
+	if params.OldString == "" {
+		if _, err := os.Stat(p); err == nil {
+			return "", fmt.Errorf("failed to edit: file already exists and old_string is empty: %s (to overwrite it, use write_file; to edit it, provide the exact text to replace in old_string)", p)
+		}
+		result, err := writeFile(root, WriteFileParams{FilePath: params.FilePath, Content: params.NewString})
+		if err != nil {
+			return "", err
+		}
+		return result, nil
+	}
+
+	if params.OldString == params.NewString {
+		return "", errors.New("failed to edit: old_string and new_string are identical")
+	}
+
+	data, err := os.ReadFile(p)
+	if err != nil {
+		return "", fmt.Errorf("failed to edit, could not read file: %w", err)
+	}
+	if isBinary(data) {
+		return "", fmt.Errorf("cannot edit binary file: %s", p)
+	}
+	content := string(data)
+
+	count := strings.Count(content, params.OldString)
+	if count == 0 {
+		return "", fmt.Errorf("failed to edit, could not find the string to replace in %s. The exact text of old_string was not found: check whitespace, indentation, and surrounding context, and re-read the file if needed", p)
+	}
+	if count > 1 && !params.AllowMultiple {
+		return "", fmt.Errorf("failed to edit, expected 1 occurrence of old_string but found %d in %s. Add more surrounding context to old_string to uniquely identify the target, or set allow_multiple to true to replace all occurrences", count, p)
+	}
+
+	content = strings.ReplaceAll(content, params.OldString, params.NewString)
+	if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+		return "", fmt.Errorf("failed to write edited file: %w", err)
+	}
+
+	if count == 1 {
+		return fmt.Sprintf("Successfully modified file: %s (1 replacement).", p), nil
+	}
+	return fmt.Sprintf("Successfully modified file: %s (%d replacements).", p, count), nil
+}

--- a/examples/sandboxed-tools/pkg/toolsets/geminicli/toolbox/toolbox.go
+++ b/examples/sandboxed-tools/pkg/toolsets/geminicli/toolbox/toolbox.go
@@ -1,0 +1,139 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package toolbox implements the filesystem tools of the geminicli toolset in
+// Go. It is compiled into the geminicli-toolbox binary, which runs *inside* the
+// sandbox: the host-side tools send the LLM's tool arguments as JSON on stdin
+// and receive the model-facing result on stdout.
+//
+// The tool names, parameters, and result formats follow gemini-cli
+// (https://github.com/google-gemini/gemini-cli, Apache-2.0, Copyright Google
+// LLC), reimplemented in Go so the sandbox image does not need Node.js.
+package toolbox
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+)
+
+// Tool names understood by Run. These match gemini-cli's tool names so that
+// prompts and model behavior transfer directly.
+const (
+	ListDirectoryToolName = "list_directory"
+	ReadFileToolName      = "read_file"
+	WriteFileToolName     = "write_file"
+	GlobToolName          = "glob"
+	GrepToolName          = "grep_search"
+	ReplaceToolName       = "replace"
+	ReadManyFilesToolName = "read_many_files"
+)
+
+// Run executes the named tool with the given JSON parameters. Relative paths
+// in the parameters are resolved against root. The returned string is the
+// model-facing tool result; a returned error is also model-facing (it
+// describes why the tool call failed, e.g. "file not found").
+func Run(ctx context.Context, root string, toolName string, paramsJSON []byte) (string, error) {
+	switch toolName {
+	case ListDirectoryToolName:
+		var params ListDirectoryParams
+		if err := unmarshalParams(paramsJSON, &params); err != nil {
+			return "", err
+		}
+		return listDirectory(root, params)
+	case ReadFileToolName:
+		var params ReadFileParams
+		if err := unmarshalParams(paramsJSON, &params); err != nil {
+			return "", err
+		}
+		return readFile(root, params)
+	case WriteFileToolName:
+		var params WriteFileParams
+		if err := unmarshalParams(paramsJSON, &params); err != nil {
+			return "", err
+		}
+		return writeFile(root, params)
+	case GlobToolName:
+		var params GlobParams
+		if err := unmarshalParams(paramsJSON, &params); err != nil {
+			return "", err
+		}
+		return glob(root, params)
+	case GrepToolName:
+		var params GrepParams
+		if err := unmarshalParams(paramsJSON, &params); err != nil {
+			return "", err
+		}
+		return grep(ctx, root, params)
+	case ReplaceToolName:
+		var params ReplaceParams
+		if err := unmarshalParams(paramsJSON, &params); err != nil {
+			return "", err
+		}
+		return replace(root, params)
+	case ReadManyFilesToolName:
+		var params ReadManyFilesParams
+		if err := unmarshalParams(paramsJSON, &params); err != nil {
+			return "", err
+		}
+		return readManyFiles(ctx, root, params)
+	default:
+		return "", fmt.Errorf("unknown tool %q", toolName)
+	}
+}
+
+func unmarshalParams(data []byte, into any) error {
+	if len(data) == 0 {
+		data = []byte("{}")
+	}
+	if err := json.Unmarshal(data, into); err != nil {
+		return fmt.Errorf("invalid tool parameters: %w", err)
+	}
+	return nil
+}
+
+// resolvePath resolves p against root; absolute paths are used as-is.
+// The sandbox provides filesystem isolation, so we don't need to do extra
+// path sanitization here.
+func resolvePath(root string, p string) string {
+	if p == "" {
+		return filepath.Clean(root)
+	}
+	if filepath.IsAbs(p) {
+		return filepath.Clean(p)
+	}
+	return filepath.Join(root, p)
+}
+
+// maxLineLength mirrors gemini-cli's MAX_LINE_LENGTH_TEXT_FILE: longer lines
+// are cut off to keep tool results bounded.
+const maxLineLength = 2000
+
+// truncateLine shortens a single line to maxLineLength characters.
+func truncateLine(line string) string {
+	runes := []rune(line)
+	if len(runes) <= maxLineLength {
+		return line
+	}
+	return string(runes[:maxLineLength]) + "... [truncated]"
+}
+
+// isBinary reports whether data looks like binary (non-text) content, using
+// the same heuristic as most tools: a NUL byte in the leading bytes.
+func isBinary(data []byte) bool {
+	n := min(len(data), 8192)
+	return bytes.IndexByte(data[:n], 0) >= 0
+}

--- a/examples/sandboxed-tools/pkg/toolsets/geminicli/toolbox/toolbox_test.go
+++ b/examples/sandboxed-tools/pkg/toolsets/geminicli/toolbox/toolbox_test.go
@@ -1,0 +1,423 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package toolbox
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// writeTestFile creates a file (and its parent directories) under root.
+func writeTestFile(t *testing.T, root string, rel string, content string) string {
+	t.Helper()
+	p := filepath.Join(root, rel)
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	return p
+}
+
+// runTool invokes Run with params marshalled to JSON, like the real binary.
+func runTool(t *testing.T, root string, tool string, params any) (string, error) {
+	t.Helper()
+	payload, err := json.Marshal(params)
+	if err != nil {
+		t.Fatalf("marshal params: %v", err)
+	}
+	return Run(t.Context(), root, tool, payload)
+}
+
+func TestRunUnknownTool(t *testing.T) {
+	if _, err := Run(t.Context(), t.TempDir(), "no_such_tool", []byte("{}")); err == nil {
+		t.Fatal("expected error for unknown tool")
+	}
+}
+
+func TestListDirectory(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, root, "b.txt", "hello")
+	writeTestFile(t, root, "a.log", "log")
+	writeTestFile(t, root, "sub/child.txt", "child")
+
+	got, err := runTool(t, root, ListDirectoryToolName, ListDirectoryParams{DirPath: "."})
+	if err != nil {
+		t.Fatalf("listDirectory: %v", err)
+	}
+	want := fmt.Sprintf("Directory listing for %s:\n[DIR] sub\na.log (3 bytes)\nb.txt (5 bytes)", root)
+	if got != want {
+		t.Errorf("listDirectory = %q, want %q", got, want)
+	}
+
+	// Ignore patterns are applied to entry names and reported.
+	got, err = runTool(t, root, ListDirectoryToolName, ListDirectoryParams{DirPath: ".", Ignore: []string{"*.log"}})
+	if err != nil {
+		t.Fatalf("listDirectory with ignore: %v", err)
+	}
+	if strings.Contains(got, "a.log") || !strings.Contains(got, "(1 ignored)") {
+		t.Errorf("listDirectory with ignore = %q, want a.log ignored", got)
+	}
+
+	if _, err := runTool(t, root, ListDirectoryToolName, ListDirectoryParams{DirPath: "missing"}); err == nil {
+		t.Error("expected error for missing directory")
+	}
+}
+
+func TestReadFile(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, root, "hello.txt", "line1\nline2\nline3\nline4\nline5")
+
+	got, err := runTool(t, root, ReadFileToolName, ReadFileParams{FilePath: "hello.txt"})
+	if err != nil {
+		t.Fatalf("readFile: %v", err)
+	}
+	if got != "line1\nline2\nline3\nline4\nline5" {
+		t.Errorf("readFile = %q", got)
+	}
+
+	// A line range triggers the truncation header with resume instructions.
+	got, err = runTool(t, root, ReadFileToolName, ReadFileParams{FilePath: "hello.txt", StartLine: 2, EndLine: 3})
+	if err != nil {
+		t.Fatalf("readFile range: %v", err)
+	}
+	if !strings.Contains(got, "Showing lines 2-3 of 5 total lines") {
+		t.Errorf("readFile range missing truncation status: %q", got)
+	}
+	if !strings.Contains(got, "start_line: 4") {
+		t.Errorf("readFile range missing resume hint: %q", got)
+	}
+	if !strings.Contains(got, "line2\nline3") {
+		t.Errorf("readFile range missing content: %q", got)
+	}
+
+	if _, err := runTool(t, root, ReadFileToolName, ReadFileParams{FilePath: "missing.txt"}); err == nil {
+		t.Error("expected error for missing file")
+	}
+	if _, err := runTool(t, root, ReadFileToolName, ReadFileParams{}); err == nil {
+		t.Error("expected error for missing file_path")
+	}
+
+	writeTestFile(t, root, "binary.bin", "abc\x00def")
+	if _, err := runTool(t, root, ReadFileToolName, ReadFileParams{FilePath: "binary.bin"}); err == nil {
+		t.Error("expected error for binary file")
+	}
+}
+
+func TestReadFileTruncatesLongFiles(t *testing.T) {
+	root := t.TempDir()
+	var sb strings.Builder
+	for i := 1; i <= maxLinesPerRead+100; i++ {
+		fmt.Fprintf(&sb, "line %d\n", i)
+	}
+	writeTestFile(t, root, "big.txt", sb.String())
+
+	got, err := runTool(t, root, ReadFileToolName, ReadFileParams{FilePath: "big.txt"})
+	if err != nil {
+		t.Fatalf("readFile: %v", err)
+	}
+	if !strings.Contains(got, "IMPORTANT: The file content has been truncated.") {
+		t.Errorf("expected truncation banner, got prefix %q", got[:100])
+	}
+	if !strings.Contains(got, fmt.Sprintf("Showing lines 1-%d", maxLinesPerRead)) {
+		t.Errorf("expected default line cap of %d, got prefix %q", maxLinesPerRead, got[:200])
+	}
+}
+
+func TestWriteFile(t *testing.T) {
+	root := t.TempDir()
+
+	got, err := runTool(t, root, WriteFileToolName, WriteFileParams{FilePath: "sub/dir/new.txt", Content: "hello"})
+	if err != nil {
+		t.Fatalf("writeFile: %v", err)
+	}
+	if !strings.Contains(got, "Successfully created and wrote to new file") {
+		t.Errorf("writeFile = %q", got)
+	}
+	data, err := os.ReadFile(filepath.Join(root, "sub/dir/new.txt"))
+	if err != nil || string(data) != "hello" {
+		t.Errorf("file content = %q, err = %v", data, err)
+	}
+
+	got, err = runTool(t, root, WriteFileToolName, WriteFileParams{FilePath: "sub/dir/new.txt", Content: "changed"})
+	if err != nil {
+		t.Fatalf("writeFile overwrite: %v", err)
+	}
+	if !strings.Contains(got, "Successfully overwrote file") {
+		t.Errorf("writeFile overwrite = %q", got)
+	}
+}
+
+func TestReplace(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, root, "code.go", "func a() {}\nfunc b() {}\nfunc b2() {}\n")
+
+	// Unique replacement succeeds.
+	got, err := runTool(t, root, ReplaceToolName, ReplaceParams{
+		FilePath:  "code.go",
+		OldString: "func a() {}",
+		NewString: "func a() { return }",
+	})
+	if err != nil {
+		t.Fatalf("replace: %v", err)
+	}
+	if !strings.Contains(got, "(1 replacement)") {
+		t.Errorf("replace = %q", got)
+	}
+	data, _ := os.ReadFile(filepath.Join(root, "code.go"))
+	if !strings.Contains(string(data), "func a() { return }") {
+		t.Errorf("file after replace = %q", data)
+	}
+
+	// Ambiguous old_string fails without allow_multiple...
+	if _, err := runTool(t, root, ReplaceToolName, ReplaceParams{
+		FilePath:  "code.go",
+		OldString: "func b",
+		NewString: "func c",
+	}); err == nil || !strings.Contains(err.Error(), "found 2") {
+		t.Errorf("expected ambiguity error, got %v", err)
+	}
+
+	// ...and succeeds with it.
+	got, err = runTool(t, root, ReplaceToolName, ReplaceParams{
+		FilePath:      "code.go",
+		OldString:     "func b",
+		NewString:     "func c",
+		AllowMultiple: true,
+	})
+	if err != nil {
+		t.Fatalf("replace allow_multiple: %v", err)
+	}
+	if !strings.Contains(got, "(2 replacements)") {
+		t.Errorf("replace allow_multiple = %q", got)
+	}
+
+	// Missing old_string fails.
+	if _, err := runTool(t, root, ReplaceToolName, ReplaceParams{
+		FilePath:  "code.go",
+		OldString: "does not exist",
+		NewString: "x",
+	}); err == nil {
+		t.Error("expected error for old_string not found")
+	}
+
+	// Identical old/new fails.
+	if _, err := runTool(t, root, ReplaceToolName, ReplaceParams{
+		FilePath:  "code.go",
+		OldString: "same",
+		NewString: "same",
+	}); err == nil {
+		t.Error("expected error for identical old_string and new_string")
+	}
+
+	// Empty old_string creates a new file, but refuses to clobber.
+	if _, err := runTool(t, root, ReplaceToolName, ReplaceParams{
+		FilePath:  "fresh.txt",
+		NewString: "created",
+	}); err != nil {
+		t.Fatalf("replace create: %v", err)
+	}
+	data, _ = os.ReadFile(filepath.Join(root, "fresh.txt"))
+	if string(data) != "created" {
+		t.Errorf("created file content = %q", data)
+	}
+	if _, err := runTool(t, root, ReplaceToolName, ReplaceParams{
+		FilePath:  "fresh.txt",
+		NewString: "clobbered",
+	}); err == nil {
+		t.Error("expected error creating file that already exists")
+	}
+}
+
+func TestGlob(t *testing.T) {
+	root := t.TempDir()
+	oldFile := writeTestFile(t, root, "old.go", "old")
+	writeTestFile(t, root, "sub/new.go", "new")
+	writeTestFile(t, root, "sub/other.txt", "other")
+	writeTestFile(t, root, ".git/config.go", "should be skipped")
+
+	// Make mtimes deterministic: old.go is older.
+	past := time.Now().Add(-time.Hour)
+	if err := os.Chtimes(oldFile, past, past); err != nil {
+		t.Fatalf("Chtimes: %v", err)
+	}
+
+	got, err := runTool(t, root, GlobToolName, GlobParams{Pattern: "**/*.go"})
+	if err != nil {
+		t.Fatalf("glob: %v", err)
+	}
+	if !strings.Contains(got, "Found 2 file(s)") {
+		t.Errorf("glob = %q", got)
+	}
+	newIdx := strings.Index(got, filepath.Join(root, "sub/new.go"))
+	oldIdx := strings.Index(got, filepath.Join(root, "old.go"))
+	if newIdx < 0 || oldIdx < 0 || newIdx > oldIdx {
+		t.Errorf("glob should list newest first: %q", got)
+	}
+	if strings.Contains(got, ".git") {
+		t.Errorf("glob should skip .git: %q", got)
+	}
+
+	got, err = runTool(t, root, GlobToolName, GlobParams{Pattern: "*.missing"})
+	if err != nil {
+		t.Fatalf("glob no match: %v", err)
+	}
+	if !strings.HasPrefix(got, "No files found matching pattern") {
+		t.Errorf("glob no match = %q", got)
+	}
+}
+
+func TestGrep(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, root, "a.go", "package main\n\nfunc Hello() {}\n")
+	writeTestFile(t, root, "b.go", "package main\n\nfunc hello2() {}\n")
+	writeTestFile(t, root, "c.txt", "hello text\n")
+
+	// Case-insensitive by default; include_pattern filters files.
+	got, err := runTool(t, root, GrepToolName, GrepParams{Pattern: "hello", IncludePattern: "*.go"})
+	if err != nil {
+		t.Fatalf("grep: %v", err)
+	}
+	if !strings.Contains(got, "Found 2 matches") {
+		t.Errorf("grep = %q", got)
+	}
+	if !strings.Contains(got, "L3: func Hello() {}") {
+		t.Errorf("grep missing match line: %q", got)
+	}
+	if strings.Contains(got, "c.txt") {
+		t.Errorf("grep include_pattern should exclude c.txt: %q", got)
+	}
+
+	// Case-sensitive narrows to one.
+	got, err = runTool(t, root, GrepToolName, GrepParams{Pattern: "Hello", CaseSensitive: true})
+	if err != nil {
+		t.Fatalf("grep case-sensitive: %v", err)
+	}
+	if !strings.Contains(got, "Found 1 match ") {
+		t.Errorf("grep case-sensitive = %q", got)
+	}
+
+	// names_only lists file paths.
+	got, err = runTool(t, root, GrepToolName, GrepParams{Pattern: "hello", NamesOnly: true})
+	if err != nil {
+		t.Fatalf("grep names_only: %v", err)
+	}
+	if !strings.Contains(got, "Found 3 files with matches") {
+		t.Errorf("grep names_only = %q", got)
+	}
+	if strings.Contains(got, "L3") {
+		t.Errorf("grep names_only should not include line numbers: %q", got)
+	}
+
+	// Context lines use '-' separators.
+	got, err = runTool(t, root, GrepToolName, GrepParams{Pattern: "func Hello", Context: 1})
+	if err != nil {
+		t.Fatalf("grep context: %v", err)
+	}
+	if !strings.Contains(got, "L2-") || !strings.Contains(got, "L3: func Hello() {}") {
+		t.Errorf("grep context = %q", got)
+	}
+
+	// No matches.
+	got, err = runTool(t, root, GrepToolName, GrepParams{Pattern: "zzznope"})
+	if err != nil {
+		t.Fatalf("grep no match: %v", err)
+	}
+	if !strings.HasPrefix(got, "No matches found") {
+		t.Errorf("grep no match = %q", got)
+	}
+
+	// total_max_matches truncates and says so.
+	got, err = runTool(t, root, GrepToolName, GrepParams{Pattern: "hello", TotalMaxMatches: 1})
+	if err != nil {
+		t.Fatalf("grep truncated: %v", err)
+	}
+	if !strings.Contains(got, "results limited to 1 matches") {
+		t.Errorf("grep truncated = %q", got)
+	}
+
+	// fixed_strings treats regex metacharacters literally.
+	writeTestFile(t, root, "d.txt", "a.b\naxb\n")
+	got, err = runTool(t, root, GrepToolName, GrepParams{Pattern: "a.b", FixedStrings: true, IncludePattern: "d.txt"})
+	if err != nil {
+		t.Fatalf("grep fixed_strings: %v", err)
+	}
+	if !strings.Contains(got, "Found 1 match ") {
+		t.Errorf("grep fixed_strings = %q", got)
+	}
+
+	// Invalid regex is a tool error.
+	if _, err := runTool(t, root, GrepToolName, GrepParams{Pattern: "("}); err == nil {
+		t.Error("expected error for invalid regex")
+	}
+}
+
+func TestReadManyFiles(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, root, "docs/a.md", "alpha")
+	writeTestFile(t, root, "docs/b.md", "beta")
+	writeTestFile(t, root, "docs/skip.bin", "bin\x00ary")
+	writeTestFile(t, root, "node_modules/dep.md", "dependency")
+
+	got, err := runTool(t, root, ReadManyFilesToolName, ReadManyFilesParams{Include: []string{"docs/**"}})
+	if err != nil {
+		t.Fatalf("readManyFiles: %v", err)
+	}
+	for _, want := range []string{
+		fmt.Sprintf("--- %s ---", filepath.Join(root, "docs/a.md")),
+		"alpha",
+		"beta",
+		"--- End of content ---",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("readManyFiles missing %q in %q", want, got)
+		}
+	}
+	if !strings.Contains(got, "skip.bin (binary file)") {
+		t.Errorf("readManyFiles should report skipped binary: %q", got)
+	}
+	if strings.Contains(got, "dependency") {
+		t.Errorf("readManyFiles should not read node_modules: %q", got)
+	}
+
+	// A directory include reads everything under it.
+	got, err = runTool(t, root, ReadManyFilesToolName, ReadManyFilesParams{Include: []string{"docs"}})
+	if err != nil {
+		t.Fatalf("readManyFiles dir include: %v", err)
+	}
+	if !strings.Contains(got, "alpha") || !strings.Contains(got, "beta") {
+		t.Errorf("readManyFiles dir include = %q", got)
+	}
+
+	// No matches.
+	got, err = runTool(t, root, ReadManyFilesToolName, ReadManyFilesParams{Include: []string{"nothing/**"}})
+	if err != nil {
+		t.Fatalf("readManyFiles no match: %v", err)
+	}
+	if got != "No files matching the criteria were found." {
+		t.Errorf("readManyFiles no match = %q", got)
+	}
+
+	// Include is required.
+	if _, err := runTool(t, root, ReadManyFilesToolName, ReadManyFilesParams{}); err == nil {
+		t.Error("expected error for missing include")
+	}
+}

--- a/examples/sandboxed-tools/pkg/toolsets/geminicli/toolbox/write_file.go
+++ b/examples/sandboxed-tools/pkg/toolsets/geminicli/toolbox/write_file.go
@@ -1,0 +1,59 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package toolbox
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// WriteFileParams are the arguments of the write_file tool.
+type WriteFileParams struct {
+	// FilePath is the file to write.
+	FilePath string `json:"file_path"`
+	// Content is the full content to write.
+	Content string `json:"content"`
+}
+
+// writeFile mirrors gemini-cli's write_file: writes the full content,
+// creating parent directories as needed.
+func writeFile(root string, params WriteFileParams) (string, error) {
+	if params.FilePath == "" {
+		return "", errors.New("file_path is required")
+	}
+	p := resolvePath(root, params.FilePath)
+
+	existed := false
+	if info, err := os.Stat(p); err == nil {
+		if info.IsDir() {
+			return "", fmt.Errorf("path is a directory, not a file: %s", p)
+		}
+		existed = true
+	}
+
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		return "", fmt.Errorf("failed to create parent directories: %w", err)
+	}
+	if err := os.WriteFile(p, []byte(params.Content), 0o644); err != nil {
+		return "", fmt.Errorf("failed to write file: %w", err)
+	}
+
+	if existed {
+		return fmt.Sprintf("Successfully overwrote file: %s", p), nil
+	}
+	return fmt.Sprintf("Successfully created and wrote to new file: %s", p), nil
+}

--- a/examples/sandboxed-tools/pkg/toolsets/geminicli/tools.go
+++ b/examples/sandboxed-tools/pkg/toolsets/geminicli/tools.go
@@ -1,0 +1,379 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// The tool names, descriptions, and parameter schemas in this file are
+// derived from gemini-cli (https://github.com/google-gemini/gemini-cli),
+// Copyright Google LLC, licensed under the Apache License 2.0
+// (packages/core/src/tools/definitions/). They are kept close to the
+// originals so that model behavior tuned for gemini-cli transfers to this
+// toolset.
+
+package geminicli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/agent-sandbox/examples/sandboxed-tools/pkg/llm"
+	"sigs.k8s.io/agent-sandbox/examples/sandboxed-tools/pkg/tools"
+	"sigs.k8s.io/agent-sandbox/examples/sandboxed-tools/pkg/toolsets/geminicli/toolbox"
+)
+
+// ToolboxBinary is the in-sandbox helper binary that implements the
+// filesystem tools; it must be on the PATH of the sandbox image (see
+// examples/sandboxed-tools/images/geminicli-toolbox).
+const ToolboxBinary = "geminicli-toolbox"
+
+// runToolbox executes one toolbox tool inside the sandbox: it sends the tool
+// parameters as JSON on stdin to `geminicli-toolbox <name>` and returns the tool
+// result. Tool failures (non-zero exit) are reported to the model as content,
+// so the model can correct its arguments and retry.
+func runToolbox(ctx context.Context, sandbox tools.Sandbox, name string, params any) (llm.Message, error) {
+	log := klog.FromContext(ctx)
+	log.Info("running toolbox tool in sandbox", "tool.name", name)
+
+	payload, err := json.Marshal(params)
+	if err != nil {
+		return llm.Message{}, fmt.Errorf("failed to encode tool parameters: %w", err)
+	}
+
+	res, err := sandbox.ExecCommand(ctx, tools.ExecCommandOptions{
+		Command: []string{ToolboxBinary, name},
+		Stdin:   bytes.NewReader(payload),
+	})
+	if err != nil {
+		return llm.Message{}, err
+	}
+
+	content := res.Stdout
+	if res.ExitCode != 0 {
+		detail := strings.TrimSpace(strings.Join([]string{res.Stderr, res.Stdout}, "\n"))
+		content = fmt.Sprintf("Error: tool %q failed (exit code %d): %s", name, res.ExitCode, detail)
+	}
+	return llm.Message{Content: &content}, nil
+}
+
+// objectSchema is a small helper to build JSON schemas for tool parameters.
+func objectSchema(properties map[string]any, required ...string) map[string]any {
+	schema := map[string]any{
+		"type":       "object",
+		"properties": properties,
+	}
+	if len(required) > 0 {
+		schema["required"] = required
+	}
+	return schema
+}
+
+// ListDirectoryTool lists the entries of a directory in the sandbox.
+type ListDirectoryTool struct {
+	toolbox.ListDirectoryParams
+}
+
+func (t *ListDirectoryTool) Schema() llm.Tool {
+	return llm.Tool{
+		Type: "function",
+		Function: llm.ToolFunction{
+			Name:        toolbox.ListDirectoryToolName,
+			Description: "Lists the names of files and subdirectories directly within a specified directory path. Can optionally ignore entries matching provided glob patterns.",
+			Parameters: objectSchema(map[string]any{
+				"dir_path": map[string]any{
+					"type":        "string",
+					"description": "The path to the directory to list",
+				},
+				"ignore": map[string]any{
+					"type":        "array",
+					"items":       map[string]any{"type": "string"},
+					"description": "List of glob patterns to ignore",
+				},
+			}, "dir_path"),
+		},
+	}
+}
+
+func (t *ListDirectoryTool) Run(ctx context.Context, sandbox tools.Sandbox) (llm.Message, error) {
+	return runToolbox(ctx, sandbox, toolbox.ListDirectoryToolName, t)
+}
+
+// ReadFileTool reads a file from the sandbox.
+//
+// TODO: gemini-cli's read_file also handles images (PNG, JPG, GIF, WEBP,
+// SVG, BMP), audio, and PDF files by returning them as inline base64 parts.
+// We only support text files (binary files are rejected); multimodal support
+// would also need pkg/llm to grow multi-part message content.
+type ReadFileTool struct {
+	toolbox.ReadFileParams
+}
+
+func (t *ReadFileTool) Schema() llm.Tool {
+	return llm.Tool{
+		Type: "function",
+		Function: llm.ToolFunction{
+			Name:        toolbox.ReadFileToolName,
+			Description: "Reads and returns the content of a specified text file. If the file is large, the content will be truncated. The tool's response will clearly indicate if truncation has occurred and will provide details on how to read more of the file using the 'start_line' and 'end_line' parameters.",
+			Parameters: objectSchema(map[string]any{
+				"file_path": map[string]any{
+					"type":        "string",
+					"description": "The path to the file to read.",
+				},
+				"start_line": map[string]any{
+					"type":        "integer",
+					"minimum":     1,
+					"description": "Optional: The 1-based line number to start reading from.",
+				},
+				"end_line": map[string]any{
+					"type":        "integer",
+					"minimum":     1,
+					"description": "Optional: The 1-based line number to end reading at (inclusive).",
+				},
+			}, "file_path"),
+		},
+	}
+}
+
+func (t *ReadFileTool) Run(ctx context.Context, sandbox tools.Sandbox) (llm.Message, error) {
+	return runToolbox(ctx, sandbox, toolbox.ReadFileToolName, t)
+}
+
+// WriteFileTool writes a file in the sandbox.
+type WriteFileTool struct {
+	toolbox.WriteFileParams
+}
+
+func (t *WriteFileTool) Schema() llm.Tool {
+	return llm.Tool{
+		Type: "function",
+		Function: llm.ToolFunction{
+			Name:        toolbox.WriteFileToolName,
+			Description: "Writes content to a specified file in the sandbox filesystem, creating parent directories if needed and overwriting any existing content.",
+			Parameters: objectSchema(map[string]any{
+				"file_path": map[string]any{
+					"type":        "string",
+					"description": "The path to the file to write to.",
+				},
+				"content": map[string]any{
+					"type":        "string",
+					"description": "The content to write to the file. Do not use omission placeholders like '(rest of methods ...)', '...', or 'unchanged code'; provide complete literal content.",
+				},
+			}, "file_path", "content"),
+		},
+	}
+}
+
+func (t *WriteFileTool) Run(ctx context.Context, sandbox tools.Sandbox) (llm.Message, error) {
+	return runToolbox(ctx, sandbox, toolbox.WriteFileToolName, t)
+}
+
+// GlobTool finds files matching glob patterns in the sandbox.
+type GlobTool struct {
+	toolbox.GlobParams
+}
+
+func (t *GlobTool) Schema() llm.Tool {
+	return llm.Tool{
+		Type: "function",
+		Function: llm.ToolFunction{
+			Name:        toolbox.GlobToolName,
+			Description: "Efficiently finds files matching specific glob patterns (e.g., `src/**/*.ts`, `**/*.md`), returning paths sorted by modification time (newest first). Ideal for quickly locating files based on their name or path structure, especially in large codebases.",
+			Parameters: objectSchema(map[string]any{
+				"pattern": map[string]any{
+					"type":        "string",
+					"description": "The glob pattern to match against (e.g., '**/*.py', 'docs/*.md').",
+				},
+				"dir_path": map[string]any{
+					"type":        "string",
+					"description": "Optional: The path to the directory to search within. If omitted, searches the workspace root directory.",
+				},
+				"case_sensitive": map[string]any{
+					"type":        "boolean",
+					"description": "Optional: Whether the search should be case-sensitive. Defaults to false.",
+				},
+			}, "pattern"),
+		},
+	}
+}
+
+func (t *GlobTool) Run(ctx context.Context, sandbox tools.Sandbox) (llm.Message, error) {
+	return runToolbox(ctx, sandbox, toolbox.GlobToolName, t)
+}
+
+// GrepTool searches file contents in the sandbox.
+type GrepTool struct {
+	toolbox.GrepParams
+}
+
+func (t *GrepTool) Schema() llm.Tool {
+	return llm.Tool{
+		Type: "function",
+		Function: llm.ToolFunction{
+			Name:        toolbox.GrepToolName,
+			Description: "Searches for a regular expression pattern within file contents.",
+			Parameters: objectSchema(map[string]any{
+				"pattern": map[string]any{
+					"type":        "string",
+					"description": `The pattern to search for. By default, treated as a regular expression. Use '\b' for precise symbol matching (e.g., '\bMatchMe\b').`,
+				},
+				"dir_path": map[string]any{
+					"type":        "string",
+					"description": "Directory or file to search. Directories are searched recursively. Relative paths are resolved against the workspace root. Defaults to the workspace root if omitted.",
+				},
+				"include_pattern": map[string]any{
+					"type":        "string",
+					"description": "Glob pattern to filter files (e.g., '*.ts', 'src/**'). Recommended for large repositories to reduce noise. Defaults to all files if omitted.",
+				},
+				"exclude_pattern": map[string]any{
+					"type":        "string",
+					"description": "Optional: A regular expression pattern to exclude from the search results. If a line matches both the pattern and the exclude_pattern, it will be omitted.",
+				},
+				"names_only": map[string]any{
+					"type":        "boolean",
+					"description": "Optional: If true, only the file paths of the matches will be returned, without the line content or line numbers. This is useful for gathering a list of files.",
+				},
+				"case_sensitive": map[string]any{
+					"type":        "boolean",
+					"description": "If true, search is case-sensitive. Defaults to false (ignore case) if omitted.",
+				},
+				"fixed_strings": map[string]any{
+					"type":        "boolean",
+					"description": "If true, treats the `pattern` as a literal string instead of a regular expression. Defaults to false (regex) if omitted.",
+				},
+				"context": map[string]any{
+					"type":        "integer",
+					"minimum":     0,
+					"description": "Show this many lines of context around each match (equivalent to grep -C). Defaults to 0 if omitted.",
+				},
+				"after": map[string]any{
+					"type":        "integer",
+					"minimum":     0,
+					"description": "Show this many lines after each match (equivalent to grep -A). Defaults to 0 if omitted.",
+				},
+				"before": map[string]any{
+					"type":        "integer",
+					"minimum":     0,
+					"description": "Show this many lines before each match (equivalent to grep -B). Defaults to 0 if omitted.",
+				},
+				"max_matches_per_file": map[string]any{
+					"type":        "integer",
+					"minimum":     1,
+					"description": "Optional: Maximum number of matches to return per file. Use this to prevent being overwhelmed by repetitive matches in large files.",
+				},
+				"total_max_matches": map[string]any{
+					"type":        "integer",
+					"minimum":     1,
+					"description": "Optional: Maximum number of total matches to return. Use this to limit the overall size of the response. Defaults to 100 if omitted.",
+				},
+			}, "pattern"),
+		},
+	}
+}
+
+func (t *GrepTool) Run(ctx context.Context, sandbox tools.Sandbox) (llm.Message, error) {
+	return runToolbox(ctx, sandbox, toolbox.GrepToolName, t)
+}
+
+// ReplaceTool performs an exact-literal-string edit of a file in the sandbox.
+type ReplaceTool struct {
+	toolbox.ReplaceParams
+}
+
+func (t *ReplaceTool) Schema() llm.Tool {
+	return llm.Tool{
+		Type: "function",
+		Function: llm.ToolFunction{
+			Name: toolbox.ReplaceToolName,
+			Description: "Replaces text within a file. By default, the tool expects to find and replace exactly ONE occurrence of `old_string`. If you want to replace multiple occurrences of the exact same string, set `allow_multiple` to true. This tool requires providing significant context around the change to ensure precise targeting. Always use the read_file tool to examine the file's current content before attempting a text replacement.\n" +
+				"Expectation for required parameters:\n" +
+				"1. `old_string` MUST be the exact literal text to replace (including all whitespace, indentation, newlines, and surrounding code etc.).\n" +
+				"2. `new_string` MUST be the exact literal text to replace `old_string` with (also including all whitespace, indentation, newlines, and surrounding code etc.). Ensure the resulting code is correct and idiomatic and that `old_string` and `new_string` are different.\n" +
+				"3. `instruction` is the detailed instruction of what needs to be changed. Make it specific and detailed so developers or large language models can understand what needs to be changed and perform the changes on their own if necessary.\n" +
+				"4. NEVER escape `old_string` or `new_string`, that would break the exact literal text requirement.\n" +
+				"**Important:** If ANY of the above are not satisfied, the tool will fail. CRITICAL for `old_string`: Must uniquely identify the instance(s) to change. Include at least 3 lines of context BEFORE and AFTER the target text, matching whitespace and indentation precisely. If this string matches multiple locations and `allow_multiple` is not true, the tool will fail.\n" +
+				"5. Prefer to break down complex and long changes into multiple smaller atomic calls to this tool. Always check the content of the file after changes or not finding a string to match.\n" +
+				"**Multiple replacements:** Set `allow_multiple` to true if you want to replace ALL occurrences that match `old_string` exactly.",
+			Parameters: objectSchema(map[string]any{
+				"file_path": map[string]any{
+					"type":        "string",
+					"description": "The path to the file to modify.",
+				},
+				"instruction": map[string]any{
+					"type": "string",
+					"description": "A clear, semantic instruction for the code change, acting as a high-quality prompt for an expert LLM assistant. It must be self-contained and explain the goal of the change.\n" +
+						"A good instruction should concisely answer:\n" +
+						"1. WHY is the change needed?\n2. WHERE should the change happen?\n3. WHAT is the high-level change?\n4. WHAT is the desired outcome?",
+				},
+				"old_string": map[string]any{
+					"type":        "string",
+					"description": "The exact literal text to replace, preferably unescaped. For single replacements (default), include at least 3 lines of context BEFORE and AFTER the target text, matching whitespace and indentation precisely. If this string is not the exact literal text (i.e. you escaped it) or does not match exactly, the tool will fail.",
+				},
+				"new_string": map[string]any{
+					"type":        "string",
+					"description": "The exact literal text to replace `old_string` with, preferably unescaped. Provide the EXACT text. Ensure the resulting code is correct and idiomatic. Do not use omission placeholders like '(rest of methods ...)', '...', or 'unchanged code'; provide exact literal code.",
+				},
+				"allow_multiple": map[string]any{
+					"type":        "boolean",
+					"description": "If true, the tool will replace all occurrences of `old_string`. If false (default), it will only succeed if exactly one occurrence is found.",
+				},
+			}, "file_path", "instruction", "old_string", "new_string"),
+		},
+	}
+}
+
+func (t *ReplaceTool) Run(ctx context.Context, sandbox tools.Sandbox) (llm.Message, error) {
+	return runToolbox(ctx, sandbox, toolbox.ReplaceToolName, t)
+}
+
+// ReadManyFilesTool reads several files from the sandbox at once.
+type ReadManyFilesTool struct {
+	toolbox.ReadManyFilesParams
+}
+
+func (t *ReadManyFilesTool) Schema() llm.Tool {
+	return llm.Tool{
+		Type: "function",
+		Function: llm.ToolFunction{
+			Name: toolbox.ReadManyFilesToolName,
+			Description: "Reads content from multiple text files specified by glob patterns, concatenating their content into a single string with a '--- {filePath} ---' separator between file contents and '--- End of content ---' after the last file.\n" +
+				"This tool is useful when you need to understand or analyze a collection of files, such as getting an overview of a codebase or parts of it, reviewing documentation files, or gathering context from multiple configuration files. Binary files are skipped. Default excludes apply to common dependency and build directories unless 'useDefaultExcludes' is false.",
+			Parameters: objectSchema(map[string]any{
+				"include": map[string]any{
+					"type":        "array",
+					"items":       map[string]any{"type": "string", "minLength": 1},
+					"minItems":    1,
+					"description": `An array of glob patterns or paths, relative to the workspace root. Examples: ["src/**/*.ts"], ["README.md", "docs/"]`,
+				},
+				"exclude": map[string]any{
+					"type":        "array",
+					"items":       map[string]any{"type": "string", "minLength": 1},
+					"description": `Optional. Glob patterns for files/directories to exclude. Added to default excludes if useDefaultExcludes is true. Example: "**/*.log", "temp/"`,
+				},
+				"recursive": map[string]any{
+					"type":        "boolean",
+					"description": "Optional. Whether to search recursively (primarily controlled by `**` in glob patterns). Defaults to true.",
+				},
+				"useDefaultExcludes": map[string]any{
+					"type":        "boolean",
+					"description": "Optional. Whether to apply a list of default exclusion patterns (e.g., node_modules, .git, binary files). Defaults to true.",
+				},
+			}, "include"),
+		},
+	}
+}
+
+func (t *ReadManyFilesTool) Run(ctx context.Context, sandbox tools.Sandbox) (llm.Message, error) {
+	return runToolbox(ctx, sandbox, toolbox.ReadManyFilesToolName, t)
+}

--- a/examples/sandboxed-tools/pkg/toolsets/geminicli/tools_test.go
+++ b/examples/sandboxed-tools/pkg/toolsets/geminicli/tools_test.go
@@ -1,0 +1,242 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package geminicli
+
+import (
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"sigs.k8s.io/agent-sandbox/examples/sandboxed-tools/pkg/tools"
+	"sigs.k8s.io/agent-sandbox/examples/sandboxed-tools/pkg/toolsets/geminicli/toolbox"
+)
+
+// fakeToolboxSandbox is a test double for tools.Sandbox that executes
+// geminicli-toolbox invocations in-process against a local directory, mirroring
+// what the real binary does inside the sandbox pod. Other commands are
+// recorded for inspection.
+type fakeToolboxSandbox struct {
+	root  string
+	calls []tools.ExecCommandOptions
+
+	// execResult is returned for non-toolbox commands (e.g. bash).
+	execResult *tools.ExecCommandResult
+	// execStdout is written to opts.Stdout for non-toolbox commands.
+	execStdout string
+}
+
+func (f *fakeToolboxSandbox) ExecCommand(ctx context.Context, opts tools.ExecCommandOptions) (*tools.ExecCommandResult, error) {
+	f.calls = append(f.calls, opts)
+
+	if len(opts.Command) >= 2 && opts.Command[0] == ToolboxBinary {
+		var params []byte
+		if opts.Stdin != nil {
+			var err error
+			params, err = io.ReadAll(opts.Stdin)
+			if err != nil {
+				return nil, err
+			}
+		}
+		content, err := toolbox.Run(ctx, f.root, opts.Command[1], params)
+		if err != nil {
+			return &tools.ExecCommandResult{ExitCode: 1, Stderr: err.Error() + "\n"}, nil
+		}
+		return &tools.ExecCommandResult{Stdout: content}, nil
+	}
+
+	if opts.Stdout != nil && f.execStdout != "" {
+		if _, err := opts.Stdout.Write([]byte(f.execStdout)); err != nil {
+			return nil, err
+		}
+	}
+	if f.execResult != nil {
+		return f.execResult, nil
+	}
+	return &tools.ExecCommandResult{}, nil
+}
+
+func TestToolsetRegisteredTools(t *testing.T) {
+	registry := tools.NewRegistry()
+	New().RegisterTools(registry)
+
+	var names []string
+	for _, schema := range registry.All() {
+		names = append(names, schema.Function.Name)
+	}
+	want := []string{
+		"glob",
+		"grep_search",
+		"list_directory",
+		"read_file",
+		"read_many_files",
+		"replace",
+		"run_shell_command",
+		"write_file",
+	}
+	if !slices.Equal(names, want) {
+		t.Errorf("registered tools = %v, want %v", names, want)
+	}
+
+	if New().SystemPrompt() == "" {
+		t.Error("SystemPrompt must not be empty")
+	}
+	if New().DefaultImage() == "" {
+		t.Error("DefaultImage must not be empty")
+	}
+}
+
+// TestToolboxToolsEndToEnd drives the host-side tools the way the registry
+// does (JSON args unmarshalled into the tool struct), against the in-process
+// toolbox.
+func TestToolboxToolsEndToEnd(t *testing.T) {
+	root := t.TempDir()
+	sandbox := &fakeToolboxSandbox{root: root}
+	ctx := t.Context()
+
+	// write_file creates a file...
+	writeTool := &WriteFileTool{}
+	writeTool.FilePath = "hello.txt"
+	writeTool.Content = "hello world"
+	msg, err := writeTool.Run(ctx, sandbox)
+	if err != nil {
+		t.Fatalf("WriteFileTool.Run: %v", err)
+	}
+	if !strings.Contains(*msg.Content, "Successfully created and wrote to new file") {
+		t.Errorf("write_file content = %q", *msg.Content)
+	}
+	if data, err := os.ReadFile(filepath.Join(root, "hello.txt")); err != nil || string(data) != "hello world" {
+		t.Errorf("written file = %q, err = %v", data, err)
+	}
+
+	// ...read_file reads it back...
+	readTool := &ReadFileTool{}
+	readTool.FilePath = "hello.txt"
+	msg, err = readTool.Run(ctx, sandbox)
+	if err != nil {
+		t.Fatalf("ReadFileTool.Run: %v", err)
+	}
+	if *msg.Content != "hello world" {
+		t.Errorf("read_file content = %q", *msg.Content)
+	}
+
+	// ...and a toolbox failure is reported as model-visible content, not an
+	// agent-loop error.
+	missingTool := &ReadFileTool{}
+	missingTool.FilePath = "missing.txt"
+	msg, err = missingTool.Run(ctx, sandbox)
+	if err != nil {
+		t.Fatalf("ReadFileTool.Run (missing): %v", err)
+	}
+	if !strings.Contains(*msg.Content, "Error: tool \"read_file\" failed") {
+		t.Errorf("read_file missing content = %q", *msg.Content)
+	}
+}
+
+func TestRunShellCommandTool(t *testing.T) {
+	sandbox := &fakeToolboxSandbox{
+		root:       t.TempDir(),
+		execStdout: "it worked\n",
+	}
+
+	tool := &RunShellCommandTool{Command: "echo 'it worked'", DirPath: "subdir"}
+	msg, err := tool.Run(t.Context(), sandbox)
+	if err != nil {
+		t.Fatalf("RunShellCommandTool.Run: %v", err)
+	}
+	if want := "Output: it worked\n"; *msg.Content != want {
+		t.Errorf("content = %q, want %q", *msg.Content, want)
+	}
+
+	if len(sandbox.calls) != 1 {
+		t.Fatalf("expected 1 exec call, got %d", len(sandbox.calls))
+	}
+	cmd := sandbox.calls[0].Command
+	// The command must be bash -c <script> <name> <dir> <user command>, so the
+	// user command is passed as a positional parameter, never interpolated.
+	if len(cmd) != 6 || cmd[0] != "bash" || cmd[1] != "-c" {
+		t.Fatalf("unexpected command shape: %v", cmd)
+	}
+	if cmd[4] != "subdir" || cmd[5] != "echo 'it worked'" {
+		t.Errorf("dir/command args = %q, %q", cmd[4], cmd[5])
+	}
+	if strings.Contains(cmd[2], "setsid") {
+		t.Errorf("foreground script should not use setsid: %q", cmd[2])
+	}
+}
+
+func TestRunShellCommandToolFailure(t *testing.T) {
+	sandbox := &fakeToolboxSandbox{
+		root:       t.TempDir(),
+		execResult: &tools.ExecCommandResult{ExitCode: 3},
+	}
+
+	tool := &RunShellCommandTool{Command: "exit 3"}
+	msg, err := tool.Run(t.Context(), sandbox)
+	if err != nil {
+		t.Fatalf("RunShellCommandTool.Run: %v", err)
+	}
+	want := "Output: (empty)\nExit Code: 3"
+	if *msg.Content != want {
+		t.Errorf("content = %q, want %q", *msg.Content, want)
+	}
+
+	if _, err := (&RunShellCommandTool{}).Run(t.Context(), sandbox); err == nil {
+		t.Error("expected error for empty command")
+	}
+}
+
+func TestRunShellCommandToolBackground(t *testing.T) {
+	sandbox := &fakeToolboxSandbox{root: t.TempDir()}
+
+	tool := &RunShellCommandTool{Command: "sleep 60", IsBackground: true}
+	if _, err := tool.Run(t.Context(), sandbox); err != nil {
+		t.Fatalf("RunShellCommandTool.Run: %v", err)
+	}
+	script := sandbox.calls[0].Command[2]
+	if !strings.Contains(script, "setsid") {
+		t.Errorf("background script should detach with setsid: %q", script)
+	}
+}
+
+// TestSchemasAreValid ensures every registered tool advertises a well-formed
+// function schema.
+func TestSchemasAreValid(t *testing.T) {
+	registry := tools.NewRegistry()
+	New().RegisterTools(registry)
+
+	for _, schema := range registry.All() {
+		if schema.Type != "function" {
+			t.Errorf("tool %q: type = %q", schema.Function.Name, schema.Type)
+		}
+		if schema.Function.Description == "" {
+			t.Errorf("tool %q: empty description", schema.Function.Name)
+		}
+		params, ok := schema.Function.Parameters.(map[string]any)
+		if !ok {
+			t.Errorf("tool %q: parameters is %T", schema.Function.Name, schema.Function.Parameters)
+			continue
+		}
+		if params["type"] != "object" {
+			t.Errorf("tool %q: parameters type = %v", schema.Function.Name, params["type"])
+		}
+		if _, ok := params["properties"].(map[string]any); !ok {
+			t.Errorf("tool %q: missing properties", schema.Function.Name)
+		}
+	}
+}

--- a/examples/sandboxed-tools/pkg/toolsets/geminicli/toolset.go
+++ b/examples/sandboxed-tools/pkg/toolsets/geminicli/toolset.go
@@ -1,0 +1,120 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package geminicli is a toolset that reproduces the gemini-cli tool surface
+// (https://github.com/google-gemini/gemini-cli, Apache-2.0) for the
+// sandboxed-tools example: the same tool names, schemas, and system prompt,
+// with the tools reimplemented in Go so no Node.js runtime is needed in the
+// sandbox.
+//
+// The filesystem tools (list_directory, read_file, write_file, glob,
+// grep_search, replace, read_many_files) are implemented by the
+// geminicli-toolbox binary running inside the sandbox (see the toolbox
+// subpackage and examples/sandboxed-tools/cmd/geminicli-toolbox);
+// run_shell_command executes bash directly. The sandbox image must therefore
+// provide bash and the geminicli-toolbox binary — see
+// examples/sandboxed-tools/images/geminicli-toolbox.
+package geminicli
+
+import (
+	"sigs.k8s.io/agent-sandbox/examples/sandboxed-tools/pkg/tools"
+)
+
+// DefaultImage is the sandbox image expected by this toolset. It is not
+// published to a registry: build it from the repo root and load it into your
+// cluster (see examples/sandboxed-tools/images/geminicli-toolbox/Dockerfile).
+const DefaultImage = "geminicli-toolbox:latest"
+
+// Toolset exposes the gemini-cli tools and prompts.
+type Toolset struct{}
+
+// New returns the geminicli toolset.
+func New() *Toolset {
+	return &Toolset{}
+}
+
+// Name implements toolsets.Toolset.
+func (t *Toolset) Name() string {
+	return "geminicli"
+}
+
+// SystemPrompt implements toolsets.Toolset.
+func (t *Toolset) SystemPrompt() string {
+	return systemPrompt
+}
+
+// RegisterTools implements toolsets.Toolset.
+//
+// This registers the subset of gemini-cli's tools that make sense in a
+// headless sandbox and that we have implemented so far. The remaining gaps,
+// from gemini-cli's full tool manifest
+// (packages/core/src/tools/definitions/base-declarations.ts), are listed
+// below; we may never implement some of them, but the list is the inventory
+// of what is missing:
+//
+// TODO: web_fetch - fetch URL(s) and process their content with a prompt.
+// Needs outbound network access from the sandbox (or host-side fetching) and
+// a summarization step; gemini-cli delegates the processing to the model.
+//
+// TODO: google_web_search - web search via the Gemini API's Google Search
+// grounding. Requires Gemini API-specific support; there is no OpenAI-compat
+// equivalent, so this would need a separate Gemini API client or a different
+// search backend.
+//
+// TODO: write_todos - subtask/progress tracking. Purely host-side state (no
+// sandbox involvement); needs somewhere to store the todo list on the
+// Session and a way to render it in the CLI.
+//
+// TODO: ask_user - structured questions back to the user (choice/text/yesno).
+// Needs harness support: a TurnEvents extension so front ends can prompt the
+// user and return the answer as the tool result.
+//
+// TODO: run_shell_command is_background parity - gemini-cli reports
+// background PIDs and the process-group PGID and offers wait/kill management
+// of background processes; we only report the PID and a log file (see
+// shell.go).
+//
+// TODO: enter_plan_mode / exit_plan_mode - read-only planning mode with a
+// plan file and an approval gate. Needs harness support (tool filtering per
+// mode and an approval flow), not just a tool implementation.
+//
+// TODO: activate_skill - agent skills loaded from the workspace
+// (.gemini/skills, and .agents/skills in newer layouts). Needs skill
+// discovery in the sandbox plus prompt wiring for <available_skills>.
+//
+// TODO: save_memory / GEMINI.md context files - gemini-cli persists
+// long-lived context by loading GEMINI.md files into the prompt and letting
+// the model edit them. Our sessions only persist chat history and the
+// sandbox filesystem; loading GEMINI.md from the sandbox home directory into
+// the system prompt would be the natural equivalent (see prompt.go).
+//
+// Not planned (gemini-cli-internal or out of scope for this example):
+// get_internal_docs, update_topic, complete_task, the subagent/tracker tools
+// (agent, tracker_create_task, tracker_list_tasks, tracker_update_task), and
+// the MCP tools (read_mcp_resource, list_mcp_resources).
+func (t *Toolset) RegisterTools(registry *tools.Registry) {
+	registry.Add(&ListDirectoryTool{})
+	registry.Add(&ReadFileTool{})
+	registry.Add(&WriteFileTool{})
+	registry.Add(&GlobTool{})
+	registry.Add(&GrepTool{})
+	registry.Add(&ReplaceTool{})
+	registry.Add(&ReadManyFilesTool{})
+	registry.Add(&RunShellCommandTool{})
+}
+
+// DefaultImage implements toolsets.Toolset.
+func (t *Toolset) DefaultImage() string {
+	return DefaultImage
+}

--- a/examples/sandboxed-tools/pkg/toolsets/toolsets.go
+++ b/examples/sandboxed-tools/pkg/toolsets/toolsets.go
@@ -1,0 +1,63 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package toolsets makes the tools and prompts of the sandboxed-tools example
+// pluggable: a Toolset bundles the system prompt, the LLM-callable tools, and
+// the sandbox image they expect, so different agent "personalities" (e.g. the
+// basic example tools, or the gemini-cli tool surface) can be selected at
+// startup without changing the agent loop.
+package toolsets
+
+import (
+	"fmt"
+	"strings"
+
+	"sigs.k8s.io/agent-sandbox/examples/sandboxed-tools/pkg/tools"
+	"sigs.k8s.io/agent-sandbox/examples/sandboxed-tools/pkg/toolsets/basic"
+	"sigs.k8s.io/agent-sandbox/examples/sandboxed-tools/pkg/toolsets/geminicli"
+)
+
+// Toolset bundles the tools and prompts that define one agent profile.
+type Toolset interface {
+	// Name is the identifier used to select the toolset (e.g. on the CLI).
+	Name() string
+
+	// SystemPrompt returns the system prompt that seeds new sessions.
+	SystemPrompt() string
+
+	// RegisterTools adds the toolset's tools to the given registry.
+	RegisterTools(registry *tools.Registry)
+
+	// DefaultImage returns the sandbox container image this toolset expects,
+	// or "" if any generic image will do.
+	DefaultImage() string
+}
+
+// Get returns the toolset with the given name; an empty name selects the
+// basic toolset.
+func Get(name string) (Toolset, error) {
+	switch name {
+	case "", "basic":
+		return basic.New(), nil
+	case "geminicli":
+		return geminicli.New(), nil
+	default:
+		return nil, fmt.Errorf("unknown toolset %q (available: %s)", name, strings.Join(Names(), ", "))
+	}
+}
+
+// Names returns the names of all available toolsets.
+func Names() []string {
+	return []string{"basic", "geminicli"}
+}

--- a/examples/sandboxed-tools/pkg/toolsets/toolsets_test.go
+++ b/examples/sandboxed-tools/pkg/toolsets/toolsets_test.go
@@ -1,0 +1,57 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package toolsets
+
+import (
+	"testing"
+
+	"sigs.k8s.io/agent-sandbox/examples/sandboxed-tools/pkg/tools"
+)
+
+func TestGet(t *testing.T) {
+	for _, name := range Names() {
+		toolset, err := Get(name)
+		if err != nil {
+			t.Fatalf("Get(%q): %v", name, err)
+		}
+		if got := toolset.Name(); got != name {
+			t.Errorf("Get(%q).Name() = %q", name, got)
+		}
+		if toolset.SystemPrompt() == "" {
+			t.Errorf("toolset %q: empty system prompt", name)
+		}
+		registry := tools.NewRegistry()
+		toolset.RegisterTools(registry)
+		if len(registry.All()) == 0 {
+			t.Errorf("toolset %q: no tools registered", name)
+		}
+	}
+}
+
+func TestGetDefaultsToBasic(t *testing.T) {
+	toolset, err := Get("")
+	if err != nil {
+		t.Fatalf("Get(\"\"): %v", err)
+	}
+	if toolset.Name() != "basic" {
+		t.Errorf("default toolset = %q, want basic", toolset.Name())
+	}
+}
+
+func TestGetUnknown(t *testing.T) {
+	if _, err := Get("no-such-toolset"); err == nil {
+		t.Fatal("expected error for unknown toolset")
+	}
+}


### PR DESCRIPTION
## Motivation

The sandboxed-tools example demonstrates running the agent loop outside the sandbox while executing tools inside it — but the tools and system prompt were hardcoded, so trying a different agent profile meant editing the agent loop. This PR makes the tools + prompts pluggable, and adds a plug-in that reproduces the [gemini-cli](https://github.com/google-gemini/gemini-cli) (Apache-2.0) tool surface so gemini-cli-style agents can run on the sandboxed-tools architecture.

## What's in the PR

**Pluggable toolsets** (`pkg/toolsets`): a `Toolset` bundles the system prompt, the LLM-callable tools, and the sandbox image they expect, selected with the new `-toolset` flag (or `TOOLSET` env var). The existing tools became the `basic` toolset and remain the default; behavior of the example is unchanged unless you opt in.

**`geminicli` toolset** (`pkg/toolsets/geminicli`): the gemini-cli tool names, parameter schemas, descriptions, result formats, and (non-interactive) system prompt, extracted from gemini-cli's tool manifest and prompt snippets with attribution, so model behavior tuned for gemini-cli transfers directly:

- `list_directory`, `read_file` (line ranges + truncation hints), `write_file`, `replace` (exact-literal edits that fail loudly on ambiguity), `glob` (`**`/`{a,b}`, newest first), `grep_search` (context lines, include globs, match caps), `read_many_files`, `run_shell_command` (background support via `is_background`).

**Tools implemented in Go, not Node**: the filesystem tools compile into a single static `geminicli-toolbox` binary that runs *inside* the sandbox (`geminicli-toolbox <tool>` with JSON args on stdin, result on stdout). `images/gemini-toolbox/Dockerfile` builds the image (debian-slim + bash/git + the binary)

**Known gaps are inventoried**: TODOs in `pkg/toolsets/geminicli` document every gemini-cli tool we don't implement (web_fetch, google_web_search, write_todos, ask_user, plan mode, skills, memory/GEMINI.md, MCP) and per-tool parity gaps (multimodal read_file, gitignore respect, background PID/PGID reporting), with notes on what implementing each would need.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable `basic` and `geminicli` toolsets for the sandboxed-tools example.
  * Added CLI selection through the `-toolset` option or `TOOLSET` environment variable.
  * Added Gemini CLI-style file, search, editing, directory, and shell tools.
  * Added automatic sandbox image selection, including a dedicated Gemini CLI toolset image.
  * Limited captured command output and indicate when it is truncated.

* **Documentation**
  * Updated setup instructions, tool descriptions, image configuration, and usage examples.

* **Tests**
  * Added coverage for toolset selection and sandbox tool behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->