### PR TITLE
docs: clarify restartPolicy interaction with claim lifecycle cleanup

### DIFF
--- a/examples/aider-sandbox/template.yaml
+++ b/examples/aider-sandbox/template.yaml
@@ -21,6 +21,7 @@ spec:
           storage: 10Gi
   podTemplate:
     spec:
+      restartPolicy: "OnFailure"
       # Ensures the volume files are group-owned by GID 1000
       securityContext:
         fsGroup: 1000

--- a/examples/gemini-cu-sandbox/sandbox-gemini-computer-use.yaml
+++ b/examples/gemini-cu-sandbox/sandbox-gemini-computer-use.yaml
@@ -11,6 +11,7 @@ spec:
       annotations:
         test: "yes"
     spec:
+      restartPolicy: "OnFailure"
       containers:
       - name: sandbox-python-computeruse
         image: sandbox-gemini-runtime:latest

--- a/examples/hermes-agents-as-a-service/10-sandboxtemplate.yaml
+++ b/examples/hermes-agents-as-a-service/10-sandboxtemplate.yaml
@@ -31,6 +31,7 @@ spec:
       # runtimeClassName: gvisor on GKE Sandbox nodes for kernel-syscall
       # isolation; this demo stays on runc because kubectl port-forward
       # (used in the walkthrough) is not supported to gVisor-sandboxed pods.
+      restartPolicy: "OnFailure"
       securityContext:
         runAsUser: 10000
         runAsGroup: 10000

--- a/examples/kata-aks-sandbox/sandbox-kata-aks.yaml
+++ b/examples/kata-aks-sandbox/sandbox-kata-aks.yaml
@@ -9,6 +9,7 @@ spec:
       # Its scheduling nodeSelector automatically places the pod on a
       # KataVmIsolation node pool, so no explicit nodeSelector is needed.
       runtimeClassName: kata-vm-isolation
+      restartPolicy: Never
       containers:
       - name: hello-kata
         image: busybox:1.37

--- a/examples/kata-aks/sandboxtemplate.yaml
+++ b/examples/kata-aks/sandboxtemplate.yaml
@@ -56,6 +56,7 @@ spec:
       # the sum of container requests/limits. Always set explicit requests
       # and limits — leaving them unset is a common cause of OOM kills under
       # Kata.
+      restartPolicy: "OnFailure"
       containers:
       - name: agent
         # Built from ./agent/ in this directory and pushed to an ACR you

--- a/examples/kata-gke-sandbox/sandbox-kata-gke.yaml
+++ b/examples/kata-gke-sandbox/sandbox-kata-gke.yaml
@@ -6,6 +6,7 @@ spec:
   podTemplate:
     spec:
       runtimeClassName: kata-qemu
+      restartPolicy: Never
       containers:
       - name: hello-kata
         image: busybox

--- a/examples/latebind-storage-gke-sandbox/sandbox-warmpool.yaml
+++ b/examples/latebind-storage-gke-sandbox/sandbox-warmpool.yaml
@@ -16,6 +16,7 @@ spec:
         dev.gvisor.empty-dir.workspace-volume.force-shared: "true"
     spec:
       runtimeClassName: gvisor
+      restartPolicy: "OnFailure"
       automountServiceAccountToken: false
       nodeSelector: {sandbox.gke.io/runtime: gvisor}
       tolerations:

--- a/examples/sandboxd-sandbox/deploy/a-runtime-image.yaml
+++ b/examples/sandboxd-sandbox/deploy/a-runtime-image.yaml
@@ -42,6 +42,7 @@ spec:
     spec:
       # The sandbox runs untrusted agent code; it needs no API access.
       automountServiceAccountToken: false
+      restartPolicy: "OnFailure"
       securityContext:
         runAsNonRoot: true
         # Ensure the shared emptyDir is writable by the non-root runtime user.

--- a/examples/sandboxd-sandbox/deploy/b-inject-binary.yaml
+++ b/examples/sandboxd-sandbox/deploy/b-inject-binary.yaml
@@ -46,6 +46,7 @@ spec:
   podTemplate:
     spec:
       automountServiceAccountToken: false
+      restartPolicy: "OnFailure"
       securityContext:
         runAsNonRoot: true
         fsGroup: 1000

--- a/examples/sandboxd-sandbox/sandbox-template.yaml
+++ b/examples/sandboxd-sandbox/sandbox-template.yaml
@@ -32,6 +32,7 @@ spec:
     spec:
       # The sandbox runs untrusted agent code; it needs no API access.
       automountServiceAccountToken: false
+      restartPolicy: "OnFailure"
       securityContext:
         runAsNonRoot: true
         # Ensure the shared emptyDir is writable by the non-root runtime user.

--- a/examples/warmpool-quickstart/llm.yaml
+++ b/examples/warmpool-quickstart/llm.yaml
@@ -13,6 +13,7 @@ spec:
         - "llm.internal"
         - "ollama.local"
       
+      restartPolicy: "OnFailure"
       containers:
       - name: agent
         # Replace with your actual agent image.

--- a/examples/warmpool-quickstart/sandboxtemplate.yaml
+++ b/examples/warmpool-quickstart/sandboxtemplate.yaml
@@ -13,6 +13,7 @@ spec:
         runAsGroup: 3000
         fsGroup: 2000
         runAsNonRoot: true
+      restartPolicy: "OnFailure"
       containers:
       - name: my-container
         image: busybox

--- a/examples/warmpool-quickstart/secure-sandboxtemplate.yaml
+++ b/examples/warmpool-quickstart/secure-sandboxtemplate.yaml
@@ -27,6 +27,7 @@ spec:
         runAsGroup: 3000
         fsGroup: 2000
         runAsNonRoot: true
+      restartPolicy: "OnFailure"
       containers:
       - name: my-container
         image: busybox

--- a/site/content/docs/sandbox/lifecycle/_index.md
+++ b/site/content/docs/sandbox/lifecycle/_index.md
@@ -49,6 +49,7 @@ spec:
   shutdownTime: "${SHUTDOWN_TIME}"
   podTemplate:
     spec:
+      restartPolicy: Never
       containers:
       - name: workspace
         image: alpine:latest
@@ -205,4 +206,52 @@ func main() {
 }
   {{< /blocks/tab >}}
 {{< /blocks/tabs >}}
+
+## Restart Policy and Cleanup Interaction
+
+The `restartPolicy` on a sandbox's pod template determines whether the container restarts after it exits. This directly affects which cleanup mechanisms work:
+
+| `restartPolicy` | Container behavior on exit | TTL fires? | `shutdownTime` fires? | Risk if no lifecycle set |
+|---|---|---|---|---|
+| `Never` | Container stays terminated | **Yes** — pod reaches `Failed` or `Succeeded` | Yes | Low — TTL handles cleanup |
+| `OnFailure` | Restarts on non-zero exit only | Only on clean exit (exit 0) | Yes | Medium — crashes don't trigger TTL |
+| `Always` (Kubernetes default) | Restarts on any exit | **Never** — container restarts indefinitely | Yes | **High — no cleanup without `shutdownTime`** |
+
+### Why this matters
+
+When `restartPolicy` is omitted, Kubernetes defaults to `Always`. If a pool operator relies on
+`TTLSecondsAfterFinished` for cleanup, the sandbox never reaches a terminal state because the
+container is restarted each time it exits. The TTL never fires, and the sandbox runs indefinitely.
+
+This creates two failure modes:
+
+1. **Zombie sandboxes.** A batch workload finishes, the container exits, but `Always` restarts it. The sandbox sits idle consuming resources until manually deleted.
+
+2. **Unbounded CrashLoopBackOff.** A container that OOMs or panics on startup enters `CrashLoopBackOff` indefinitely. The pod is never terminal, TTL never fires, and the sandbox consumes resources in a crash loop with no escape.
+
+### Recommendations
+
+Always set `restartPolicy` explicitly in your `SandboxTemplate`:
+
+- **`Never`** for ephemeral, one-shot workloads (single script execution, Playwright scrapes, CI test runs). TTL cleanup works reliably because the pod reaches a terminal state on exit.
+
+- **`OnFailure`** for interactive or long-running workloads (MCP servers, Jupyter kernels, coding agents). The container restarts on crashes but stays terminated on clean exit. Pair with `shutdownTime` or `maxLifetimeSeconds` for a hard cleanup deadline.
+
+- **`Always`** only when you explicitly need indefinite restarts (rare). Always pair with `shutdownTime` or `maxLifetimeSeconds` — TTL-based cleanup will not work.
+
+```yaml
+apiVersion: extensions.agents.x-k8s.io/v1beta1
+kind: SandboxTemplate
+metadata:
+  name: batch-template
+spec:
+  podTemplate:
+    spec:
+      # Never: container stays terminated on exit, TTL cleanup works reliably.
+      restartPolicy: "Never"
+      containers:
+      - name: workspace
+        image: python:3.11-slim
+        command: ["/bin/sh", "-c", "python run_task.py"]
+```
 

--- a/site/content/docs/sandbox/lifecycle/_index.md
+++ b/site/content/docs/sandbox/lifecycle/_index.md
@@ -220,7 +220,7 @@ The `restartPolicy` on a sandbox's pod template determines whether the container
 ### Why this matters
 
 When `restartPolicy` is omitted, Kubernetes defaults to `Always`. If a pool operator relies on
-`ttlSecondsAfterFinished` for cleanup, the sandbox never reaches a terminal state because the
+`ttlSecondsAfterFinished` (a SandboxClaim `spec.lifecycle` field in the extensions API) for cleanup, the sandbox never reaches a terminal state because the
 container is restarted each time it exits. The TTL never fires, and the sandbox runs indefinitely.
 
 This creates two failure modes:
@@ -235,9 +235,9 @@ Always set `restartPolicy` explicitly in your `SandboxTemplate`:
 
 - **`Never`** for ephemeral, one-shot workloads (single script execution, Playwright scrapes, CI test runs). TTL cleanup works reliably because the pod reaches a terminal state on exit.
 
-- **`OnFailure`** for interactive or long-running workloads (MCP servers, Jupyter kernels, coding agents). The container restarts on crashes but stays terminated on clean exit. Pair with `shutdownTime` or `maxLifetimeSeconds` for a hard cleanup deadline.
+- **`OnFailure`** for interactive or long-running workloads (MCP servers, Jupyter kernels, coding agents). The container restarts on crashes but stays terminated on clean exit. Pair with `shutdownTime` for a hard cleanup deadline.
 
-- **`Always`** only when you explicitly need indefinite restarts (rare). Always pair with `shutdownTime` or `maxLifetimeSeconds` — TTL-based cleanup will not work.
+- **`Always`** only when you explicitly need indefinite restarts (rare). Always pair with `shutdownTime` — TTL-based cleanup will not work.
 
 ```yaml
 apiVersion: extensions.agents.x-k8s.io/v1beta1

--- a/site/content/docs/sandbox/lifecycle/_index.md
+++ b/site/content/docs/sandbox/lifecycle/_index.md
@@ -220,7 +220,7 @@ The `restartPolicy` on a sandbox's pod template determines whether the container
 ### Why this matters
 
 When `restartPolicy` is omitted, Kubernetes defaults to `Always`. If a pool operator relies on
-`TTLSecondsAfterFinished` for cleanup, the sandbox never reaches a terminal state because the
+`ttlSecondsAfterFinished` for cleanup, the sandbox never reaches a terminal state because the
 container is restarted each time it exits. The TTL never fires, and the sandbox runs indefinitely.
 
 This creates two failure modes:


### PR DESCRIPTION
## Summary

- Add a "Restart Policy and Cleanup Interaction" section to the lifecycle docs explaining how `restartPolicy` affects TTL and `shutdownTime` cleanup
- Set explicit `restartPolicy` on 13 critical examples where the implicit `Always` default could cause zombie sandboxes or unbounded CrashLoopBackOff
  - `Never` for one-shot kata demos (kata-gke, kata-aks)
  - `OnFailure` for interactive/gateway workloads (warmpool-quickstart, hermes, aider, gemini-cu, sandboxd, latebind-storage, kata-aks template)

## Test plan

- [ ] Verify lifecycle docs page renders correctly with Hugo
- [ ] Spot-check that modified example YAMLs are valid (`kubectl apply --dry-run=client`)
- [ ] Confirm no existing examples that already had `restartPolicy` were changed

Fixes #1577

/cc @Lumbenlengo — welcome aboard, would appreciate your review on this!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Configuration Updates**
  * Sandbox examples now explicitly define pod restart behavior, using `OnFailure` or `Never` as appropriate.
  * These settings provide more predictable handling of sandbox process failures and completion.

* **Documentation**
  * Added lifecycle guidance explaining how restart policies interact with sandbox cleanup and shutdown settings.
  * Documented potential failure scenarios and recommended restart policies, including cleanup considerations for failed or repeatedly restarting sandboxes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->