### PR TITLE
ci: use repo-wide golangci-lint in olm and fix protobuf doc comments

### DIFF
--- a/olm/Makefile
+++ b/olm/Makefile
@@ -242,12 +242,11 @@ KUBECTL ?= kubectl
 KIND ?= kind
 KUSTOMIZE ?= $(LOCALBIN)/kustomize
 CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen
-GOLANGCI_LINT = $(LOCALBIN)/golangci-lint
+GOLANGCI_LINT ?= go tool -modfile=$(REPO_ROOT)/dev/tools/go.mod golangci-lint
 
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v5.6.0
 CONTROLLER_TOOLS_VERSION ?= v0.18.0
-GOLANGCI_LINT_VERSION ?= v2.1.0
 
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.
@@ -260,9 +259,8 @@ $(CONTROLLER_GEN): $(LOCALBIN)
 	$(call go-install-tool,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen,$(CONTROLLER_TOOLS_VERSION))
 
 .PHONY: golangci-lint
-golangci-lint: $(GOLANGCI_LINT) ## Download golangci-lint locally if necessary.
-$(GOLANGCI_LINT): $(LOCALBIN)
-	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/v2/cmd/golangci-lint,$(GOLANGCI_LINT_VERSION))
+golangci-lint: ## Verify golangci-lint is available via dev/tools/go.mod.
+	$(GOLANGCI_LINT) version
 
 # go-install-tool will 'go install' any package with custom target and name of binary, if it doesn't exist
 # $1 - target path with name of binary

--- a/packages/sandboxd/spec/process/v1/process.pb.go
+++ b/packages/sandboxd/spec/process/v1/process.pb.go
@@ -360,7 +360,6 @@ type StartResponse struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Types that are assignable to Event:
-	//
 	//	*StartResponse_Init
 	//	*StartResponse_Stdout
 	//	*StartResponse_Stderr
@@ -584,7 +583,6 @@ type WriteStdinRequest struct {
 
 	ProcessId int32 `protobuf:"varint,1,opt,name=process_id,json=processId,proto3" json:"process_id,omitempty"`
 	// Types that are assignable to Payload:
-	//
 	//	*WriteStdinRequest_Input
 	//	*WriteStdinRequest_Eof
 	Payload isWriteStdinRequest_Payload `protobuf_oneof:"payload"`


### PR DESCRIPTION
#### What this PR does / why we need it:
Fixes two failures breaking presubmits on `main` after recent CI environment / Go toolchain updates:

1. **`presubmit-agent-sandbox-lint-olm`**: `olm/Makefile` pinned an older `golangci-lint` version (`v2.1.0`) and used a local download target. This failed under the updated Go toolchain in CI. We update `olm/Makefile` to use `go tool -modfile=$(REPO_ROOT)/dev/tools/go.mod golangci-lint`, aligning it with the rest of the repository and making `dev/tools/go.mod` the single source of truth.
2. **`presubmit-test-autogen-up-to-date`**: Regenerates `packages/sandboxd/spec/process/v1/process.pb.go` to remove redundant blank comment lines formatted away by newer `go/format`.

#### Which issue(s) this PR is related to:

#### Release Note
```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the development tooling workflow to use the configured golangci-lint tool directly.
  * The linting check now verifies that golangci-lint is available rather than downloading it automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->