### PR TITLE
docs: document high-throughput tuning, connection sharding, and refill shaping flags

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -6,13 +6,13 @@ The `agent-sandbox-controller` supports several command-line flags to tune perfo
 
 * `--sandbox-concurrent-workers` (default: 100): The maximum number of concurrent reconciles for the Sandbox controller.
 * `--sandbox-claim-concurrent-workers` (default: 50): The maximum number of concurrent reconciles for the SandboxClaim controller.
-* `--sandbox-warm-pool-concurrent-workers` (default: 1): The maximum number of concurrent reconciles for the SandboxWarmPool controller. Keep this at 1 (or small) to prevent multiple reconciler workers from racing each other on the same pool's expectations tracker.
+* `--sandbox-warm-pool-concurrent-workers` (default: 1): The maximum number of concurrent reconciles for the SandboxWarmPool controller. Reconciles for a given pool key are serialized by the workqueue, so workers provide concurrency across distinct warm pools rather than within a single pool. Size this to the number of active warm pools in the cluster and available API capacity (e.g. 1 is sufficient if managing a single warm pool).
 * `--sandbox-template-concurrent-workers` (default: 1): The maximum number of concurrent reconciles for the SandboxTemplate controller.
 * `--sandbox-warm-pool-max-batch-size` (default: 300): The maximum number of sandboxes the SandboxWarmPool controller will create/delete in a single batch. Creates advance one observed batch per watch round-trip (the expectations gate waits for a batch's add events before issuing the next), so a large pool fills in about `ceil(replicas/batchSize)` round-trips; raising this trades round-trips for burst size and is safe at any value under the gate.
 * `--sandbox-warm-pool-readiness-grace-period` (default: `5m`): How long a warm pool sandbox may stay non-Ready before the SandboxWarmPool controller considers it stuck and replaces it (or holds it, if its pod is unschedulable). Raise this for images with long initialization or clusters with slow node auto-provisioning. Must be a positive duration.
 * `--sandbox-warm-pool-unschedulable-recheck-interval` (default: `1m`): Requeue interval at which the SandboxWarmPool controller re-checks a pool holding unschedulable sandboxes past the readiness grace period. Must be a positive duration.
 * `--kube-api-qps` (default: -1, no client-side rate limiting): Client-side QPS limit for the Kubernetes API client.
-* `--kube-api-burst` (default: 10): The maximum burst for client-side throttling of the Kubernetes API client. When running high worker concurrency or experiencing client-side throttling, raise this (e.g. 100–200).
+* `--kube-api-burst` (default: 10): The maximum burst for client-side throttling of the Kubernetes API client. Only applies when `--kube-api-qps` is set to a positive value (client-side rate limiting enabled). When running high worker concurrency with a positive `--kube-api-qps`, raise this (e.g. 100–200) to match or exceed worker concurrency to avoid client-side throttling.
 
 ## API Transport and Connection Settings
 
@@ -127,7 +127,7 @@ When running high sustained claim rates (e.g., 10–20+ claims/second) or managi
    At high throughput, routine event generation and annotation updates write heavily to etcd:
    * **Fix**: Enable `--disable-claim-events=true` and `--disable-claim-observability-annotations=true` to eliminate ~40 write QPS at 20 claims/s.
    * **Fix**: Enable `--cache-label-selectors=true` to avoid caching non-sandbox pods and services across the cluster.
-   * **Fix**: Ensure `--kube-api-burst=200` to prevent client-side rate limiting from throttling worker reconciles.
+   * **Fix**: If using client-side rate limiting (`--kube-api-qps`), ensure `--kube-api-burst` (e.g. `200`) is sized to match or exceed worker concurrency to prevent client-side throttling. By default, `--kube-api-qps=-1` (client-side rate limiting is disabled).
 
 ### High-Throughput Deployment Example
 
@@ -137,11 +137,22 @@ kind: Deployment
 metadata:
   name: agent-sandbox-controller
   namespace: agent-sandbox-system
+  labels:
+    app: agent-sandbox-controller
 spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: agent-sandbox-controller
   template:
+    metadata:
+      labels:
+        app: agent-sandbox-controller
     spec:
+      serviceAccountName: agent-sandbox-controller
       containers:
       - name: agent-sandbox-controller
+        image: ko://sigs.k8s.io/agent-sandbox/cmd/agent-sandbox-controller # replace with published image or deploy with ko
         args:
         - --leader-elect=true
         - --extensions=true
@@ -155,8 +166,7 @@ spec:
         - --disable-claim-events=true
         - --disable-claim-observability-annotations=true
         - --cache-label-selectors=true
-        - --kube-api-burst=200
-        # Worker concurrency
+        # Worker concurrency (size warm-pool workers to the number of distinct pools)
         - --sandbox-claim-concurrent-workers=100
         - --sandbox-concurrent-workers=150
         - --sandbox-warm-pool-concurrent-workers=1

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -6,12 +6,31 @@ The `agent-sandbox-controller` supports several command-line flags to tune perfo
 
 * `--sandbox-concurrent-workers` (default: 100): The maximum number of concurrent reconciles for the Sandbox controller.
 * `--sandbox-claim-concurrent-workers` (default: 50): The maximum number of concurrent reconciles for the SandboxClaim controller.
-* `--sandbox-warm-pool-concurrent-workers` (default: 1): The maximum number of concurrent reconciles for the SandboxWarmPool controller.
-* `--sandbox-warm-pool-max-batch-size` (default: 300): The maximum number of sandboxes the SandboxWarmPool controller will create/delete in a single batch.
+* `--sandbox-warm-pool-concurrent-workers` (default: 1): The maximum number of concurrent reconciles for the SandboxWarmPool controller. Keep this at 1 (or small) to prevent multiple reconciler workers from racing each other on the same pool's expectations tracker.
+* `--sandbox-template-concurrent-workers` (default: 1): The maximum number of concurrent reconciles for the SandboxTemplate controller.
+* `--sandbox-warm-pool-max-batch-size` (default: 300): The maximum number of sandboxes the SandboxWarmPool controller will create/delete in a single batch. Creates advance one observed batch per watch round-trip (the expectations gate waits for a batch's add events before issuing the next), so a large pool fills in about `ceil(replicas/batchSize)` round-trips; raising this trades round-trips for burst size and is safe at any value under the gate.
 * `--sandbox-warm-pool-readiness-grace-period` (default: `5m`): How long a warm pool sandbox may stay non-Ready before the SandboxWarmPool controller considers it stuck and replaces it (or holds it, if its pod is unschedulable). Raise this for images with long initialization or clusters with slow node auto-provisioning. Must be a positive duration.
 * `--sandbox-warm-pool-unschedulable-recheck-interval` (default: `1m`): Requeue interval at which the SandboxWarmPool controller re-checks a pool holding unschedulable sandboxes past the readiness grace period. Must be a positive duration.
 * `--kube-api-qps` (default: -1, no client-side rate limiting): Client-side QPS limit for the Kubernetes API client.
-* `--kube-api-burst` (default: 10): The maximum burst for client-side throttling of the Kubernetes API client.
+* `--kube-api-burst` (default: 10): The maximum burst for client-side throttling of the Kubernetes API client. When running high worker concurrency or experiencing client-side throttling, raise this (e.g. 100–200).
+
+## API Transport and Connection Settings
+
+* `--separate-watch-connection` (default: `false`): Give the manager's informer cache (list/watch streams) a dedicated HTTP/2 connection to the API server. Watch events arrive on existing long-lived streams, so this isolates their frames from TCP/connection-level queuing behind bursts of request traffic on a shared connection (HTTP/2 stream prioritization does not help in practice). Strongly recommended for high-throughput or bursty environments to prevent watch starvation.
+* `--api-connections` (default: `1`): Number of independent HTTP/2 connections to the API server for non-watch traffic (writes, uncached reads, events, leader election). The `kube-apiserver` caps concurrent in-flight requests per HTTP/2 connection (`SETTINGS_MAX_CONCURRENT_STREAMS`; 100 by default, configurable server-side via `--http2-max-streams-per-connection`), so a single connection bounds effective concurrency at the advertised limit regardless of worker count or QPS settings. Values > 1 shard requests round-robin across that many dedicated connections (~N x per-connection limit ceiling).
+
+## Warm Pool Replenishment Shaping
+
+* `--sandbox-warm-pool-max-refill-rate` (default: `0`, unpaced): Max rate (sandboxes/second, per pool) at which the SandboxWarmPool controller creates replacement sandboxes, pacing replenishment via a token bucket into a smooth stream instead of full-deficit bursts that flood the write path and compete with claim adoption. `0` (default) leaves refill unpaced (whole deficit per reconcile).
+* `--sandbox-warm-pool-replenish-delay` (default: `0`): How long the SandboxWarmPool controller defers creating replacement sandboxes after pool members drop out of the pool (e.g. a burst of SandboxClaims adopting warm sandboxes), so the burst gets API server priority. The hold re-arms while members keep dropping. `0` (default) replenishes immediately.
+* `--enable-warm-pool-eviction` (default: `true`): Mark pods created by a warm pool as ready-to-evict by default.
+
+## API Write and Cache Optimization
+
+* `--disable-claim-events` (default: `false`): Disable Kubernetes Event emission from the SandboxClaim controller (its `Eventf` calls become no-ops), reducing API server and etcd write volume during large claim bursts.
+* `--disable-claim-observability-annotations` (default: `false`): Skip persisting the SandboxClaim observability annotations (controller first-observed timestamp, trace context), removing one API write per claim. The values are still stamped on the in-memory object, so startup-latency metrics and trace propagation keep working within the controller process.
+* `--cache-label-selectors` (default: `false`): Scope the manager's Pod and Service informer caches to objects carrying the sandbox tracking label (`agents.x-k8s.io/sandbox-name-hash`). The controller only ever creates/looks up Pods and Services it labeled itself, so on shared or high-churn clusters this cuts informer list/watch volume, JSON decode CPU, and cache memory from O(cluster) to O(sandboxes). CAVEAT: externally pre-provisioned resources that rely on the `agents.x-k8s.io/adoptable=true` adoption path MUST also carry the tracking label (value = the owning sandbox's name hash) to remain visible to the controller when this flag is enabled.
+* `--sandbox-write-behind-window` (default: `0`): Coalescing window for the Sandbox controller's recoverable metadata-only writes. `0` disables coalescing.
 
 ## Cluster Settings
 
@@ -89,6 +108,58 @@ Then include the patch in your `kustomization.yaml`:
 ```yaml
 patches:
   - path: patch-args.yaml
+```
+
+## High-Throughput & Scale Tuning
+
+When running high sustained claim rates (e.g., 10–20+ claims/second) or managing large warm pools (e.g., 1,000–2,500+ replicas), standard controller deployments can experience API server bottlenecks and warm-pool replenishment stalls:
+
+1. **Watch Stream Starvation & The Expectations Gate**:
+   The `SandboxWarmPool` reconciler gates sandbox creation using an in-flight expectations tracker (`warmPoolExpectations`). When creating replacement sandboxes, it waits for the informer cache to observe all watch `ADD` events before issuing further creates.
+   If writes and watch streams share a single HTTP/2 connection (`--separate-watch-connection=false`), large write bursts queue or drop watch frames. This causes create expectations to remain unsatisfied, wedging the warm pool until the 5-minute fallback timeout (`expectationsTimeout = 5m`) expires.
+   * **Fix**: Enable `--separate-watch-connection=true` and shard write traffic with `--api-connections=4` (or `8`).
+
+2. **Replenishment Pacing**:
+   By default, replenishment is unpaced (`--sandbox-warm-pool-max-refill-rate=0`), causing the controller to attempt to satisfy the entire deficit at once in giant batches. This floods the API server with parallel POST requests, triggering API Priority & Fairness (APF) throttling.
+   * **Fix**: Set `--sandbox-warm-pool-max-refill-rate` (e.g. `25`–`30` for a sustained 20 claims/s workload) to pace replenishment smoothly, and bound `--sandbox-warm-pool-max-batch-size=200`.
+
+3. **Reducing API Server & etcd Pressure**:
+   At high throughput, routine event generation and annotation updates write heavily to etcd:
+   * **Fix**: Enable `--disable-claim-events=true` and `--disable-claim-observability-annotations=true` to eliminate ~40 write QPS at 20 claims/s.
+   * **Fix**: Enable `--cache-label-selectors=true` to avoid caching non-sandbox pods and services across the cluster.
+   * **Fix**: Ensure `--kube-api-burst=200` to prevent client-side rate limiting from throttling worker reconciles.
+
+### High-Throughput Deployment Example
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: agent-sandbox-controller
+  namespace: agent-sandbox-system
+spec:
+  template:
+    spec:
+      containers:
+      - name: agent-sandbox-controller
+        args:
+        - --leader-elect=true
+        - --extensions=true
+        # Connection sharding and watch isolation
+        - --separate-watch-connection=true
+        - --api-connections=4
+        # Replenishment pacing
+        - --sandbox-warm-pool-max-refill-rate=25
+        - --sandbox-warm-pool-max-batch-size=200
+        # Write and cache optimization
+        - --disable-claim-events=true
+        - --disable-claim-observability-annotations=true
+        - --cache-label-selectors=true
+        - --kube-api-burst=200
+        # Worker concurrency
+        - --sandbox-claim-concurrent-workers=100
+        - --sandbox-concurrent-workers=150
+        - --sandbox-warm-pool-concurrent-workers=1
 ```
 
 ## SandboxClaim label-domain allowlist

--- a/site/content/docs/performance-assessment/_index.md
+++ b/site/content/docs/performance-assessment/_index.md
@@ -27,7 +27,7 @@ The `agent-sandbox-controller` exposes several flags that directly affect throug
 | `--sandbox-warm-pool-replenish-delay` | `0` | Defer warm pool replenishment after claims adopt members so burst adoptions get API server priority |
 | `--disable-claim-events` | `false` | Suppresses Kubernetes Event emission from the SandboxClaim controller to cut API and etcd write traffic |
 | `--disable-claim-observability-annotations` | `false` | Skips persisting first-observed timestamp and trace annotations to etcd while preserving in-memory metrics |
-| `--cache-label-selectors` | `false` | Scopes Pod and Service informer caches to sandbox tracking labels, avoiding caching unrelated cluster resources. Caveat: externally pre-provisioned Pods and Services relying on adoption must also carry `agents.x-k8s.io/sandbox-name-hash` to be visible to the controller. |
+| `--cache-label-selectors` | `false` | Scopes Pod and Service informer caches to sandbox tracking labels, avoiding caching unrelated cluster resources. Caveat: externally pre-provisioned Pods and Services relying on adoption must carry `agents.x-k8s.io/sandbox-name-hash` set to the owning sandbox's name hash to be visible to the controller. |
 | `--sandbox-write-behind-window` | `0` | Coalescing window for recoverable metadata-only writes on Sandboxes |
 
 ### Choosing worker counts

--- a/site/content/docs/performance-assessment/_index.md
+++ b/site/content/docs/performance-assessment/_index.md
@@ -16,7 +16,7 @@ The `agent-sandbox-controller` exposes several flags that directly affect throug
 |------|---------|-------------|
 | `--sandbox-concurrent-workers` | `100` | Max concurrent reconciles for the Sandbox controller |
 | `--sandbox-claim-concurrent-workers` | `50` | Max concurrent reconciles for the SandboxClaim controller |
-| `--sandbox-warm-pool-concurrent-workers` | `1` | Max concurrent reconciles for the SandboxWarmPool controller. Keep at 1 (or small) to prevent reconciler workers from racing on the pool expectations tracker. |
+| `--sandbox-warm-pool-concurrent-workers` | `1` | Max concurrent reconciles for the SandboxWarmPool controller. Reconciles are serialized per pool key by the workqueue, so workers provide concurrency across distinct pools. Size to the number of active warm pools in the cluster. |
 | `--sandbox-template-concurrent-workers` | `1` | Max concurrent reconciles for the SandboxTemplate controller |
 | `--sandbox-warm-pool-max-batch-size` | `300` | Max sandboxes the SandboxWarmPool controller creates or deletes in a single batch |
 | `--kube-api-qps` | `-1` (no client-side throttling) | Disables client-side rate limiting to the Kubernetes API server. Server-side throttling (API Priority and Fairness) still applies. When setting a positive value, use at least the sum of all `--*-concurrent-workers` flags to avoid starving reconcile loops. |
@@ -27,7 +27,7 @@ The `agent-sandbox-controller` exposes several flags that directly affect throug
 | `--sandbox-warm-pool-replenish-delay` | `0` | Defer warm pool replenishment after claims adopt members so burst adoptions get API server priority |
 | `--disable-claim-events` | `false` | Suppresses Kubernetes Event emission from the SandboxClaim controller to cut API and etcd write traffic |
 | `--disable-claim-observability-annotations` | `false` | Skips persisting first-observed timestamp and trace annotations to etcd while preserving in-memory metrics |
-| `--cache-label-selectors` | `false` | Scopes Pod and Service informer caches to sandbox tracking labels, avoiding caching unrelated cluster resources |
+| `--cache-label-selectors` | `false` | Scopes Pod and Service informer caches to sandbox tracking labels, avoiding caching unrelated cluster resources. Caveat: externally pre-provisioned Pods and Services relying on adoption must also carry `agents.x-k8s.io/sandbox-name-hash` to be visible to the controller. |
 | `--sandbox-write-behind-window` | `0` | Coalescing window for recoverable metadata-only writes on Sandboxes |
 
 ### Choosing worker counts

--- a/site/content/docs/performance-assessment/_index.md
+++ b/site/content/docs/performance-assessment/_index.md
@@ -16,11 +16,19 @@ The `agent-sandbox-controller` exposes several flags that directly affect throug
 |------|---------|-------------|
 | `--sandbox-concurrent-workers` | `100` | Max concurrent reconciles for the Sandbox controller |
 | `--sandbox-claim-concurrent-workers` | `50` | Max concurrent reconciles for the SandboxClaim controller |
-| `--sandbox-warm-pool-concurrent-workers` | `1` | Max concurrent reconciles for the SandboxWarmPool controller |
+| `--sandbox-warm-pool-concurrent-workers` | `1` | Max concurrent reconciles for the SandboxWarmPool controller. Keep at 1 (or small) to prevent reconciler workers from racing on the pool expectations tracker. |
 | `--sandbox-template-concurrent-workers` | `1` | Max concurrent reconciles for the SandboxTemplate controller |
 | `--sandbox-warm-pool-max-batch-size` | `300` | Max sandboxes the SandboxWarmPool controller creates or deletes in a single batch |
 | `--kube-api-qps` | `-1` (no client-side throttling) | Disables client-side rate limiting to the Kubernetes API server. Server-side throttling (API Priority and Fairness) still applies. When setting a positive value, use at least the sum of all `--*-concurrent-workers` flags to avoid starving reconcile loops. |
 | `--kube-api-burst` | `10` | Max burst for API server throttle requests. Ignored when `--kube-api-qps` is `-1`. When `--kube-api-qps` is set to a positive value, set this to equal or greater than `--kube-api-qps`. Must stay a positive integer even when unused — the controller exits on startup if it's `<= 0`. |
+| `--separate-watch-connection` | `false` | Dedicates an isolated HTTP/2 connection to the API server for list/watch streams, preventing write traffic from starving informer watch frames |
+| `--api-connections` | `1` | Number of independent HTTP/2 connections for non-watch requests, sharding writes to bypass the API server's per-connection concurrency limit (`SETTINGS_MAX_CONCURRENT_STREAMS`) |
+| `--sandbox-warm-pool-max-refill-rate` | `0` (unpaced) | Max sandboxes/sec created per pool to pace replenishment and prevent API server write bursts |
+| `--sandbox-warm-pool-replenish-delay` | `0` | Defer warm pool replenishment after claims adopt members so burst adoptions get API server priority |
+| `--disable-claim-events` | `false` | Suppresses Kubernetes Event emission from the SandboxClaim controller to cut API and etcd write traffic |
+| `--disable-claim-observability-annotations` | `false` | Skips persisting first-observed timestamp and trace annotations to etcd while preserving in-memory metrics |
+| `--cache-label-selectors` | `false` | Scopes Pod and Service informer caches to sandbox tracking labels, avoiding caching unrelated cluster resources |
+| `--sandbox-write-behind-window` | `0` | Coalescing window for recoverable metadata-only writes on Sandboxes |
 
 ### Choosing worker counts
 
@@ -142,6 +150,12 @@ patches:
       name: agent-sandbox-controller
       namespace: agent-sandbox-system
 ```
+
+### High-Throughput & Scale Tuning
+
+For high-throughput workloads (such as sustained claim rates of 10–20+ claims/sec or large warm pools with >1,000 replicas), standard worker tuning alone may lead to API server throttling, HTTP/2 stream saturation, or watch frame starvation behind large write bursts.
+
+For in-depth architectural explanations, recommended flag combinations, and a complete tuned Deployment manifest, refer to the [High-Throughput & Scale Tuning](https://github.com/kubernetes-sigs/agent-sandbox/blob/main/docs/configuration.md#high-throughput--scale-tuning) section in `docs/configuration.md`.
 
 ---
 


### PR DESCRIPTION
#### What this PR does / why we need it:

Under high sustained claim rates (e.g. 10–20+ claims/sec) or large warm pools (>1,000 replicas), default controller deployments can encounter API server write spikes and warm-pool replenishment stalls due to HTTP/2 stream saturation and watch frame queueing behind write bursts (expectations gate timeout).

This PR updates `docs/configuration.md` and `site/content/docs/performance-assessment/_index.md` to document several flags and features added for high scale:
- **API transport & connection settings**: `--separate-watch-connection` (dedicates an isolated HTTP/2 connection for list/watch informer streams) and `--api-connections` (shards non-watch traffic across N connections to bypass `SETTINGS_MAX_CONCURRENT_STREAMS`).
- **Warm pool replenishment shaping**: `--sandbox-warm-pool-max-refill-rate` (paces pool creates via token bucket) and `--sandbox-warm-pool-replenish-delay` (defers refill during claim bursts).
- **API write & cache optimizations**: `--disable-claim-events`, `--disable-claim-observability-annotations`, `--cache-label-selectors`, and `--sandbox-write-behind-window`.
- **High-throughput tuning guide & sample Deployment**: provides architecture rationale for the expectations gate fallback and a recommended Deployment configuration.

#### Which issue(s) this PR is related to:

Ref #1240
Ref #1251

#### Release Note

```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that warm-pool work is serialized per pool key and recommended sizing workers to active pools.
  * Documented that API burst behavior applies only when QPS is positive.
  * Updated high-throughput guidance to reflect disabled default client-side rate limiting.
  * Added a complete, valid high-throughput deployment example.
  * Documented required owning sandbox name-hash labels for pre-provisioned Pods and Services used with cache selectors.
  * Expanded performance assessment guidance with tuning recommendations and configuration references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->