### PR TITLE
Fix path sanitization through symlinked roots

### DIFF
--- a/packages/sandboxd/pkg/pathutil/sandbox.go
+++ b/packages/sandboxd/pkg/pathutil/sandbox.go
@@ -45,6 +45,7 @@ func SanitizePath(rootDir, userPath string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("invalid sandbox root dir: %w", err)
 	}
+	lexicalRoot := cleanRoot
 
 	cleanRootSymlink, err := filepath.EvalSymlinks(cleanRoot)
 	if err == nil {
@@ -53,12 +54,14 @@ func SanitizePath(rootDir, userPath string) (string, error) {
 
 	// Join root with user path directly to preserve relative ".." components
 	// so they are neutralized by Clean before symlink evaluation. Trim
-	// cleanRoot prefix with separator boundary if user supplied a full
-	// absolute path under cleanRoot.
+	// either root prefix with a separator boundary if the user supplied a
+	// full absolute path through the lexical or resolved root.
 	userPathClean := filepath.Clean(userPath)
-	if userPathClean == cleanRoot {
+	if userPathClean == cleanRoot || userPathClean == lexicalRoot {
 		userPathClean = "."
 	} else if after, found := strings.CutPrefix(userPathClean, cleanRoot+string(os.PathSeparator)); found {
+		userPathClean = after
+	} else if after, found := strings.CutPrefix(userPathClean, lexicalRoot+string(os.PathSeparator)); found {
 		userPathClean = after
 	}
 	joined := filepath.Clean(filepath.Join(cleanRoot, userPathClean))

--- a/packages/sandboxd/pkg/pathutil/sandbox_test.go
+++ b/packages/sandboxd/pkg/pathutil/sandbox_test.go
@@ -74,6 +74,21 @@ func TestSanitizePathAbsolutePathConfined(t *testing.T) {
 	require.Equal(t, filepath.Join(resolvedRoot, "f.txt"), gotFull)
 }
 
+func TestSanitizePathAbsolutePathConfinedThroughRootSymlink(t *testing.T) {
+	base := t.TempDir()
+	root := filepath.Join(base, "root")
+	rootAlias := filepath.Join(base, "root-alias")
+	require.NoError(t, os.Mkdir(root, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "f.txt"), []byte("x"), 0o644))
+	require.NoError(t, os.Symlink(root, rootAlias))
+
+	got, err := SanitizePath(rootAlias, filepath.Join(rootAlias, "f.txt"))
+	require.NoError(t, err)
+	resolvedRoot, err := filepath.EvalSymlinks(root)
+	require.NoError(t, err)
+	require.Equal(t, filepath.Join(resolvedRoot, "f.txt"), got)
+}
+
 func TestSanitizePathSiblingPrefixAbsolute(t *testing.T) {
 	base := t.TempDir()
 	root := filepath.Join(base, "workspace")


### PR DESCRIPTION
#### What this PR does / why we need it:
SanitizePath resolves the sandbox root before comparing full absolute user paths against it. When the root is accessed through a symlink alias, such as macOS /var mapping to /private/var, that comparison misses and duplicates the absolute path beneath the root.

This change preserves the cleaned lexical root for prefix recognition while continuing to use the resolved root for final path confinement. It also adds a portable regression test using a symlinked sandbox root.

#### Which issue(s) this PR is related to:
None.

#### Release Note
```release-note
Fix path sanitization when sandbox roots are accessed through symlink aliases.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of absolute paths when the sandbox root is accessed through a symlink.
  - Paths that remain within the aliased sandbox root are now resolved correctly without being rejected as escapes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->