### PR TITLE
Add configurable TLS version and cipher suites for controller and router

### DIFF
--- a/cmd/agent-sandbox-controller/main.go
+++ b/cmd/agent-sandbox-controller/main.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 	"net/http/pprof"
 	"os"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"sync"
@@ -84,6 +85,10 @@ func main() {
 	var printVersion bool
 	var disableClaimEvents bool
 	var disableClaimObservabilityAnnotations bool
+	var metricsSecureServing bool
+	var metricsCertDir string
+	var tlsMinVersion string
+	var tlsCipherSuites string
 
 	flag.BoolVar(&printVersion, "version", false, "Print version information and exit.")
 	flag.StringVar(&clusterDomain, "cluster-domain", "cluster.local", "Kubernetes cluster domain for service FQDN generation")
@@ -157,6 +162,22 @@ func main() {
 			"by the previous process. Default false (annotations persisted).")
 	flag.DurationVar(&sandboxWriteBehindWindow, "sandbox-write-behind-window", 0,
 		"Coalescing window for the Sandbox controller's recoverable metadata-only writes. 0 disables coalescing.")
+	flag.BoolVar(&metricsSecureServing, "metrics-secure-serving", false,
+		"Serve metrics over HTTPS instead of HTTP. When enabled without --metrics-cert-dir, "+
+			"a self-signed certificate is generated automatically. Conventional HTTPS metrics port is :8443.")
+	flag.StringVar(&metricsCertDir, "metrics-cert-dir", "",
+		"Directory containing tls.crt and tls.key for the metrics server. "+
+			"Only used when --metrics-secure-serving is enabled.")
+	flag.StringVar(&tlsMinVersion, "tls-min-version", "",
+		"Minimum TLS version for the metrics server. "+
+			"Accepted values: VersionTLS10, VersionTLS11, VersionTLS12, VersionTLS13. "+
+			"If not set, the Go default applies (TLS 1.2). "+
+			"A downstream operator can use this flag to inject the cluster TLS profile.")
+	flag.StringVar(&tlsCipherSuites, "tls-cipher-suites", "",
+		"Comma-separated list of cipher suites for the metrics server, "+
+			"using Go cipher-suite names (e.g. TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256). "+
+			"If not set, the Go default applies. TLS 1.3 cipher suites are not configurable. "+
+			"A downstream operator can use this flag to inject the cluster TLS profile.")
 	opts := zap.Options{
 		Development: false,
 	}
@@ -279,6 +300,39 @@ func main() {
 
 	metricsOpts := metricsserver.Options{
 		BindAddress: metricsAddr,
+	}
+	if metricsSecureServing {
+		metricsOpts.SecureServing = true
+		if metricsCertDir != "" {
+			certPath := filepath.Join(metricsCertDir, "tls.crt")
+			keyPath := filepath.Join(metricsCertDir, "tls.key")
+			if _, err := os.Stat(certPath); err != nil {
+				setupLog.Error(err, "metrics cert not found", "path", certPath)
+				os.Exit(1)
+			}
+			if _, err := os.Stat(keyPath); err != nil {
+				setupLog.Error(err, "metrics key not found", "path", keyPath)
+				os.Exit(1)
+			}
+			metricsOpts.CertDir = metricsCertDir
+		}
+		setupLog.Info("metrics server TLS enabled (--metrics-secure-serving)")
+		tlsOpts, err := buildMetricsTLSOpts(tlsMinVersion, tlsCipherSuites)
+		if err != nil {
+			setupLog.Error(err, "invalid TLS configuration")
+			os.Exit(1)
+		}
+		if len(tlsOpts) > 0 {
+			metricsOpts.TLSOpts = append(metricsOpts.TLSOpts, tlsOpts...)
+			kv := []any{"minVersion", tlsMinVersion}
+			if tlsCipherSuites != "" && tlsMinVersion != "VersionTLS13" {
+				kv = append(kv, "cipherSuites", tlsCipherSuites)
+			}
+			setupLog.Info("TLS configuration applied to metrics server", kv...)
+		}
+	} else if metricsCertDir != "" || tlsMinVersion != "" || tlsCipherSuites != "" {
+		setupLog.Error(nil, "TLS flags require --metrics-secure-serving")
+		os.Exit(1)
 	}
 	if enablePprof || enablePprofDebug {
 		setupLog.Info("pprof enabled", "debug", enablePprofDebug)

--- a/cmd/agent-sandbox-controller/tlsconfig.go
+++ b/cmd/agent-sandbox-controller/tlsconfig.go
@@ -1,0 +1,53 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"crypto/tls"
+	"strings"
+
+	inttls "sigs.k8s.io/agent-sandbox/internal/tlsutil"
+)
+
+func buildMetricsTLSOpts(minVersion, cipherSuites string) ([]func(*tls.Config), error) {
+	var opts []func(*tls.Config)
+
+	var minVer uint16
+	if minVersion != "" {
+		var err error
+		minVer, err = inttls.ParseTLSVersion(minVersion)
+		if err != nil {
+			return nil, err
+		}
+		opts = append(opts, func(c *tls.Config) {
+			c.MinVersion = minVer
+		})
+	}
+
+	if cipherSuites != "" {
+		names := strings.Split(cipherSuites, ",")
+		ids, err := inttls.ParseCipherSuites(names)
+		if err != nil {
+			return nil, err
+		}
+		if len(ids) > 0 && minVer < tls.VersionTLS13 {
+			opts = append(opts, func(c *tls.Config) {
+				c.CipherSuites = ids
+			})
+		}
+	}
+
+	return opts, nil
+}

--- a/cmd/agent-sandbox-controller/tlsconfig_test.go
+++ b/cmd/agent-sandbox-controller/tlsconfig_test.go
@@ -1,0 +1,103 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"crypto/tls"
+	"testing"
+)
+
+func TestBuildMetricsTLSOpts(t *testing.T) {
+	tests := []struct {
+		name         string
+		minVersion   string
+		cipherSuites string
+		wantNil      bool
+		wantErr      bool
+	}{
+		{"empty_inputs", "", "", true, false},
+		{"version_only", "VersionTLS12", "", false, false},
+		{"ciphers_only", "", "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256", false, false},
+		{"version_and_ciphers", "VersionTLS12", "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256", false, false},
+		{"invalid_version", "VersionTLS99", "", false, true},
+		{"invalid_cipher", "VersionTLS12", "BOGUS_CIPHER", false, true},
+		{"tls13_skips_ciphers", "VersionTLS13", "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256", false, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := buildMetricsTLSOpts(tt.minVersion, tt.cipherSuites)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("buildMetricsTLSOpts(%q, %q) error = %v, wantErr %v", tt.minVersion, tt.cipherSuites, err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+			if tt.wantNil && len(got) != 0 {
+				t.Errorf("expected nil/empty opts, got %d", len(got))
+			}
+			if !tt.wantNil && len(got) == 0 {
+				t.Errorf("expected non-empty opts, got nil")
+			}
+		})
+	}
+
+	t.Run("applies_minversion", func(t *testing.T) {
+		opts, err := buildMetricsTLSOpts("VersionTLS13", "")
+		if err != nil {
+			t.Fatal(err)
+		}
+		cfg := &tls.Config{}
+		for _, fn := range opts {
+			fn(cfg)
+		}
+		if cfg.MinVersion != tls.VersionTLS13 {
+			t.Errorf("MinVersion = %d, want %d", cfg.MinVersion, tls.VersionTLS13)
+		}
+	})
+
+	t.Run("applies_ciphers", func(t *testing.T) {
+		opts, err := buildMetricsTLSOpts("VersionTLS12", "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256")
+		if err != nil {
+			t.Fatal(err)
+		}
+		cfg := &tls.Config{}
+		for _, fn := range opts {
+			fn(cfg)
+		}
+		if cfg.MinVersion != tls.VersionTLS12 {
+			t.Errorf("MinVersion = %d, want %d", cfg.MinVersion, tls.VersionTLS12)
+		}
+		if len(cfg.CipherSuites) != 1 || cfg.CipherSuites[0] != tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 {
+			t.Errorf("CipherSuites = %v, want [%d]", cfg.CipherSuites, tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256)
+		}
+	})
+
+	t.Run("tls13_no_ciphers_applied", func(t *testing.T) {
+		opts, err := buildMetricsTLSOpts("VersionTLS13", "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256")
+		if err != nil {
+			t.Fatal(err)
+		}
+		cfg := &tls.Config{}
+		for _, fn := range opts {
+			fn(cfg)
+		}
+		if cfg.MinVersion != tls.VersionTLS13 {
+			t.Errorf("MinVersion = %d, want %d", cfg.MinVersion, tls.VersionTLS13)
+		}
+		if len(cfg.CipherSuites) != 0 {
+			t.Errorf("CipherSuites should be empty for TLS 1.3, got %v", cfg.CipherSuites)
+		}
+	})
+}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -172,6 +172,31 @@ spec:
         - --sandbox-warm-pool-concurrent-workers=1
 ```
 
+## TLS Settings
+
+The controller's metrics server can optionally serve over HTTPS with configurable TLS parameters. This is primarily useful for downstream distributions that enforce a cluster-wide TLS security profile.
+
+* `--metrics-secure-serving` (default: `false`): Serve metrics over HTTPS instead of HTTP. When enabled without `--metrics-cert-dir`, a self-signed certificate is generated automatically.
+* `--metrics-cert-dir` (default: `""`): Directory containing `tls.crt` and `tls.key` for the metrics server. Only used when `--metrics-secure-serving` is enabled. The controller exits at startup if either file is missing.
+* `--tls-min-version` (default: Go default, currently TLS 1.2): Minimum TLS version for the metrics server. Accepted values: `VersionTLS10`, `VersionTLS11`, `VersionTLS12`, `VersionTLS13`.
+* `--tls-cipher-suites` (default: Go defaults): Comma-separated list of cipher suites using Go cipher-suite names (e.g. `TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256`). TLS 1.3 cipher suites are not configurable in Go and are ignored when `--tls-min-version=VersionTLS13`.
+
+**Example: HTTPS metrics with explicit TLS profile**
+
+```yaml
+      containers:
+      - name: agent-sandbox-controller
+        args:
+        - --leader-elect=true
+        - --metrics-secure-serving
+        - --metrics-bind-address=:8443
+        - --metrics-cert-dir=/etc/metrics-certs
+        - --tls-min-version=VersionTLS12
+        - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+```
+
+A downstream operator can inject the cluster TLS profile by translating it into these flags and patching the controller Deployment.
+
 ## SandboxClaim label-domain allowlist
 
 Since v0.5.0, label keys in `SandboxClaim.spec.additionalPodMetadata.labels`

--- a/internal/tlsutil/tls.go
+++ b/internal/tlsutil/tls.go
@@ -1,0 +1,90 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tlsutil
+
+import (
+	"crypto/tls"
+	"fmt"
+	"strings"
+)
+
+// ParseTLSVersion maps a version name to the corresponding crypto/tls
+// constant. The accepted names match the Kubernetes API server's
+// --tls-min-version flag.
+func ParseTLSVersion(v string) (uint16, error) {
+	switch v {
+	case "VersionTLS10":
+		return tls.VersionTLS10, nil
+	case "VersionTLS11":
+		return tls.VersionTLS11, nil
+	case "VersionTLS12":
+		return tls.VersionTLS12, nil
+	case "VersionTLS13":
+		return tls.VersionTLS13, nil
+	default:
+		return 0, fmt.Errorf("unknown TLS version %q; must be one of: VersionTLS10, VersionTLS11, VersionTLS12, VersionTLS13", v)
+	}
+}
+
+// tls13CipherSuites lists the standard TLS 1.3 cipher suite names. Go
+// manages these automatically and does not expose them via
+// tls.CipherSuites(), but cluster TLS profiles may
+// include them alongside TLS 1.2 suites. Recognizing them here lets a
+// profile be injected without modification.
+var tls13CipherSuites = map[string]bool{
+	"TLS_AES_128_GCM_SHA256":       true,
+	"TLS_AES_256_GCM_SHA384":       true,
+	"TLS_CHACHA20_POLY1305_SHA256": true,
+}
+
+// IsTLS13CipherSuite reports whether name is a standard TLS 1.3 cipher
+// suite that Go manages automatically and cannot be configured via
+// tls.Config.CipherSuites.
+func IsTLS13CipherSuite(name string) bool {
+	return tls13CipherSuites[strings.TrimSpace(name)]
+}
+
+// ParseCipherSuites converts Go cipher-suite names to their numeric IDs.
+// Unknown names cause an error. Names are looked up in
+// tls.CipherSuites but not in tls.InsecureCipherSuites. Standard TLS
+// 1.3 cipher suite names are recognized and silently skipped because Go
+// manages them automatically.
+func ParseCipherSuites(names []string) ([]uint16, error) {
+	if len(names) == 0 {
+		return nil, nil
+	}
+
+	supported := make(map[string]uint16)
+	for _, cs := range tls.CipherSuites() {
+		supported[cs.Name] = cs.ID
+	}
+
+	var ids []uint16
+	for _, name := range names {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
+		}
+		if tls13CipherSuites[name] {
+			continue
+		}
+		id, ok := supported[name]
+		if !ok {
+			return nil, fmt.Errorf("unknown cipher suite %q", name)
+		}
+		ids = append(ids, id)
+	}
+	return ids, nil
+}

--- a/internal/tlsutil/tls_test.go
+++ b/internal/tlsutil/tls_test.go
@@ -1,0 +1,183 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tlsutil
+
+import (
+	"crypto/tls"
+	"testing"
+)
+
+func TestParseTLSVersion(t *testing.T) {
+	cases := []struct {
+		input string
+		want  uint16
+		err   bool
+	}{
+		{"VersionTLS10", tls.VersionTLS10, false},
+		{"VersionTLS11", tls.VersionTLS11, false},
+		{"VersionTLS12", tls.VersionTLS12, false},
+		{"VersionTLS13", tls.VersionTLS13, false},
+		{"TLS1.2", 0, true},
+		{"", 0, true},
+	}
+	for _, tc := range cases {
+		name := tc.input
+		if name == "" {
+			name = "<empty>"
+		}
+		t.Run(name, func(t *testing.T) {
+			got, err := ParseTLSVersion(tc.input)
+			if tc.err {
+				if err == nil {
+					t.Fatalf("expected error for %q", tc.input)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("got %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestParseCipherSuites(t *testing.T) {
+	t.Run("nil on empty", func(t *testing.T) {
+		ids, err := ParseCipherSuites(nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if ids != nil {
+			t.Fatalf("expected nil, got %v", ids)
+		}
+	})
+
+	t.Run("valid suites", func(t *testing.T) {
+		names := []string{
+			"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+			"TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+		}
+		ids, err := ParseCipherSuites(names)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(ids) != 2 {
+			t.Fatalf("expected 2 IDs, got %d", len(ids))
+		}
+		if ids[0] != tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 {
+			t.Errorf("first suite: got %#x, want %#x", ids[0], tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256)
+		}
+		if ids[1] != tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 {
+			t.Errorf("second suite: got %#x, want %#x", ids[1], tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384)
+		}
+	})
+
+	t.Run("trims whitespace", func(t *testing.T) {
+		ids, err := ParseCipherSuites([]string{"  TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256  "})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(ids) != 1 {
+			t.Fatalf("expected 1 ID, got %d", len(ids))
+		}
+	})
+
+	t.Run("skips empty entries", func(t *testing.T) {
+		ids, err := ParseCipherSuites([]string{"", "  "})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(ids) != 0 {
+			t.Fatalf("expected 0 IDs, got %d", len(ids))
+		}
+	})
+
+	t.Run("unknown suite", func(t *testing.T) {
+		_, err := ParseCipherSuites([]string{"TLS_BOGUS_CIPHER"})
+		if err == nil {
+			t.Fatalf("expected error for unknown suite")
+		}
+	})
+
+	t.Run("silently skips TLS 1.3 suites", func(t *testing.T) {
+		names := []string{
+			"TLS_AES_128_GCM_SHA256",
+			"TLS_AES_256_GCM_SHA384",
+			"TLS_CHACHA20_POLY1305_SHA256",
+		}
+		ids, err := ParseCipherSuites(names)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(ids) != 0 {
+			t.Fatalf("expected 0 IDs (all TLS 1.3 skipped), got %d", len(ids))
+		}
+	})
+
+	t.Run("mixed TLS 1.2 and 1.3 suites", func(t *testing.T) {
+		names := []string{
+			"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+			"TLS_AES_128_GCM_SHA256",
+			"TLS_AES_256_GCM_SHA384",
+		}
+		ids, err := ParseCipherSuites(names)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(ids) != 1 {
+			t.Fatalf("expected 1 ID (TLS 1.3 skipped), got %d", len(ids))
+		}
+		if ids[0] != tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 {
+			t.Errorf("got %#x, want %#x", ids[0], tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256)
+		}
+	})
+
+	t.Run("rejects insecure suites", func(t *testing.T) {
+		for _, suite := range tls.InsecureCipherSuites() {
+			t.Run(suite.Name, func(t *testing.T) {
+				_, err := ParseCipherSuites([]string{suite.Name})
+				if err == nil {
+					t.Errorf("expected error for insecure suite %q", suite.Name)
+				}
+			})
+		}
+	})
+}
+
+func TestIsTLS13CipherSuite(t *testing.T) {
+	tls13 := []string{
+		"TLS_AES_128_GCM_SHA256",
+		"TLS_AES_256_GCM_SHA384",
+		"TLS_CHACHA20_POLY1305_SHA256",
+	}
+	for _, name := range tls13 {
+		if !IsTLS13CipherSuite(name) {
+			t.Errorf("expected %q to be a TLS 1.3 suite", name)
+		}
+	}
+
+	notTLS13 := []string{
+		"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+		"TLS_BOGUS",
+		"",
+	}
+	for _, name := range notTLS13 {
+		if IsTLS13CipherSuite(name) {
+			t.Errorf("expected %q to NOT be a TLS 1.3 suite", name)
+		}
+	}
+}

--- a/k8s/controller.yaml
+++ b/k8s/controller.yaml
@@ -72,6 +72,12 @@ spec:
         image: ko://sigs.k8s.io/agent-sandbox/cmd/agent-sandbox-controller # placeholder value, replaced by deployment scripts
         args:
         - --leader-elect=true
+        # Uncomment to serve metrics over HTTPS with a TLS profile:
+        # - --metrics-secure-serving
+        # - --metrics-bind-address=:8443
+        # - --metrics-cert-dir=/etc/metrics-certs
+        # - --tls-min-version=VersionTLS12
+        # - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
         ports:
         - name: metrics
           containerPort: 8080
@@ -79,4 +85,13 @@ spec:
         - name: healthz
           containerPort: 8081
           protocol: TCP
+        # Uncomment when --metrics-secure-serving is enabled:
+        # volumeMounts:
+        # - name: metrics-certs
+        #   mountPath: /etc/metrics-certs
+        #   readOnly: true
+      # volumes:
+      # - name: metrics-certs
+      #   secret:
+      #     secretName: agent-sandbox-metrics-tls
 

--- a/k8s/extensions.controller.yaml
+++ b/k8s/extensions.controller.yaml
@@ -23,6 +23,12 @@ spec:
         args:
         - "--leader-elect=true"
         - "--extensions"
+        # Uncomment to serve metrics over HTTPS with a TLS profile:
+        # - "--metrics-secure-serving"
+        # - "--metrics-bind-address=:8443"
+        # - "--metrics-cert-dir=/etc/metrics-certs"
+        # - "--tls-min-version=VersionTLS12"
+        # - "--tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384"
         ports:
         - name: metrics
           containerPort: 8080
@@ -34,10 +40,18 @@ spec:
         - name: config-volume
           mountPath: /etc/sandbox-config
           readOnly: true
+        # Uncomment when --metrics-secure-serving is enabled:
+        # - name: metrics-certs
+        #   mountPath: /etc/metrics-certs
+        #   readOnly: true
       volumes:
       - name: config-volume
         configMap:
           name: agent-sandbox-config
           optional: true
+      # Uncomment when --metrics-secure-serving is enabled:
+      # - name: metrics-certs
+      #   secret:
+      #     secretName: agent-sandbox-metrics-tls
 
 

--- a/sandbox-router/README.md
+++ b/sandbox-router/README.md
@@ -131,6 +131,8 @@ Run `sandbox-router --help` for the full list. The most relevant:
 | `--health-probe-bind-address` | `:8081` | `/healthz` and `/readyz`. |
 | `--tls-cert-file` / `--tls-key-file` | — | PEM-encoded server cert and key. Hot-reloaded on file change (via fsnotify on the parent directory, so atomic Secret rotation just works). |
 | `--tls-client-ca-file` | — | CA bundle for verifying client certs when mTLS is on. |
+| `--tls-min-version` | `""` (TLS 1.2) | Minimum TLS version: `VersionTLS10`, `VersionTLS11`, `VersionTLS12`, `VersionTLS13`. Honors `TLS_MIN_VERSION`. |
+| `--tls-cipher-suites` | `""` (Go defaults) | Comma-separated Go cipher-suite names. Honors `TLS_CIPHER_SUITES`. Ignored when min version is TLS 1.3. |
 | `--mtls-mode` | `off` | `off` / `optional` / `required`. |
 | `--cluster-domain` | `cluster.local` | Honors `CLUSTER_DOMAIN` env var (Python parity). |
 | `--proxy-timeout` | `180s` | Per-request upstream timeout. Honors `PROXY_TIMEOUT_SECONDS` (numeric seconds). |
@@ -286,7 +288,7 @@ The HTTPS listener is opt-in (set `--https-bind-address`). Cert and key are read
 - `optional` — if the client presents a cert, it must validate against `--tls-client-ca-file`; if it doesn't, the request proceeds.
 - `required` — every connection must present a cert that validates against the CA bundle.
 
-`tls.Config.MinVersion = TLS 1.2`. ALPN advertises `h2` and `http/1.1`.
+`tls.Config.MinVersion` defaults to TLS 1.2 and is configurable via `--tls-min-version` (or the `TLS_MIN_VERSION` env var). Cipher suites can be set via `--tls-cipher-suites` (or `TLS_CIPHER_SUITES`); when omitted, Go defaults apply. ALPN advertises `h2` and `http/1.1`. A downstream operator can inject the cluster TLS profile via these flags or env vars.
 
 ## Metrics
 
@@ -340,6 +342,8 @@ https-bind-address: ":8443"
 tls-cert-file: "/tls/tls.crt"
 tls-key-file: "/tls/tls.key"
 tls-client-ca-file: "/tls/ca.crt"
+tls-min-version: "VersionTLS12"
+tls-cipher-suites: "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"
 mtls-mode: "required"
 cluster-domain: "cluster.local"
 proxy-timeout: "180s"

--- a/sandbox-router/config/config.go
+++ b/sandbox-router/config/config.go
@@ -105,6 +105,13 @@ type Config struct {
 	TLSClientCAFile string
 	// MTLSMode selects the client-certificate verification policy.
 	MTLSMode MTLSMode
+	// TLSMinVersion is the minimum TLS version for the HTTPS proxy listener.
+	// Accepted values: VersionTLS10, VersionTLS11, VersionTLS12, VersionTLS13.
+	// Empty defaults to VersionTLS12.
+	TLSMinVersion string
+	// TLSCipherSuites is an optional list of cipher suites for the HTTPS
+	// proxy listener, using Go cipher-suite names. Empty uses Go defaults.
+	TLSCipherSuites []string
 
 	// ClusterDomain is the Kubernetes cluster DNS suffix used to build target
 	// service FQDNs (e.g. "cluster.local"). Honors CLUSTER_DOMAIN.
@@ -363,6 +370,14 @@ func (c *Config) Validate() error {
 		}
 		if c.TLSClientCAFile == "" {
 			return fmt.Errorf("--mtls-mode=%s requires --tls-client-ca-file", c.MTLSMode)
+		}
+	}
+
+	if c.HTTPSAddr != "" && c.TLSMinVersion != "" {
+		switch c.TLSMinVersion {
+		case "VersionTLS10", "VersionTLS11", "VersionTLS12", "VersionTLS13":
+		default:
+			return fmt.Errorf("invalid --tls-min-version %q; must be one of: VersionTLS10, VersionTLS11, VersionTLS12, VersionTLS13", c.TLSMinVersion)
 		}
 	}
 

--- a/sandbox-router/config/config_test.go
+++ b/sandbox-router/config/config_test.go
@@ -73,6 +73,25 @@ func TestApplyEnvDefaults(t *testing.T) {
 			want: func(c *Config) bool { return c.ClusterDomain == "cluster.local" },
 		},
 		{
+			name: "tls min version from env",
+			env:  map[string]string{EnvTLSMinVersion: "VersionTLS13"},
+			want: func(c *Config) bool { return c.TLSMinVersion == "VersionTLS13" },
+		},
+		{
+			name: "tls cipher suites from env",
+			env:  map[string]string{EnvTLSCipherSuites: "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256, TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"},
+			want: func(c *Config) bool {
+				return len(c.TLSCipherSuites) == 2 &&
+					c.TLSCipherSuites[0] == "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256" &&
+					c.TLSCipherSuites[1] == "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"
+			},
+		},
+		{
+			name: "empty tls min version keeps default",
+			env:  map[string]string{EnvTLSMinVersion: ""},
+			want: func(c *Config) bool { return c.TLSMinVersion == "" },
+		},
+		{
 			name: "no env keeps defaults",
 			env:  map[string]string{},
 			want: func(c *Config) bool {
@@ -270,6 +289,33 @@ func TestValidate(t *testing.T) {
 				c.MTLSMode = MTLSOptional
 			},
 			wantErr: "tls-client-ca-file",
+		},
+		{
+			name: "invalid tls min version",
+			mut: func(c *Config) {
+				c.HTTPSAddr = ":8443"
+				c.TLSCertFile = "/c"
+				c.TLSKeyFile = "/k"
+				c.TLSMinVersion = "TLS1.2"
+			},
+			wantErr: "invalid --tls-min-version",
+		},
+		{
+			name: "valid tls min version",
+			mut: func(c *Config) {
+				c.HTTPSAddr = ":8443"
+				c.TLSCertFile = "/c"
+				c.TLSKeyFile = "/k"
+				c.TLSMinVersion = "VersionTLS12"
+			},
+			wantErr: "",
+		},
+		{
+			name: "tls min version ignored without https",
+			mut: func(c *Config) {
+				c.TLSMinVersion = "VersionTLS12"
+			},
+			wantErr: "",
 		},
 		{
 			name:    "negative proxy timeout",

--- a/sandbox-router/config/flags.go
+++ b/sandbox-router/config/flags.go
@@ -38,6 +38,9 @@ const (
 	EnvOTLPEndpoint        = "OTEL_EXPORTER_OTLP_ENDPOINT"
 	EnvOTLPTracesEndpoint  = "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"
 	EnvOTLPMetricsEndpoint = "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT"
+
+	EnvTLSMinVersion   = "TLS_MIN_VERSION"
+	EnvTLSCipherSuites = "TLS_CIPHER_SUITES"
 )
 
 // LookupEnvFunc matches the signature of os.LookupEnv. Tests inject a fake.
@@ -73,6 +76,15 @@ func RegisterFlags(fs *flag.FlagSet, c *Config, lookup LookupEnvFunc) {
 			"when --mtls-mode is optional or required.")
 	stringEnumVar(fs, (*string)(&c.MTLSMode), "mtls-mode", string(c.MTLSMode),
 		"Client-cert verification policy: off, optional, or required.")
+	fs.StringVar(&c.TLSMinVersion, "tls-min-version", c.TLSMinVersion,
+		"Minimum TLS version for the HTTPS proxy listener. "+
+			"Accepted values: VersionTLS10, VersionTLS11, VersionTLS12, VersionTLS13. "+
+			"Default: VersionTLS12 (applied when empty). "+
+			"Honors "+EnvTLSMinVersion+".")
+	stringSliceVar(fs, &c.TLSCipherSuites, "tls-cipher-suites",
+		"Comma-separated cipher suites for the HTTPS proxy listener, using Go "+
+			"cipher-suite names (e.g. TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256). "+
+			"Default: Go defaults. Honors "+EnvTLSCipherSuites+".")
 
 	fs.StringVar(&c.ClusterDomain, "cluster-domain", c.ClusterDomain,
 		"Kubernetes cluster DNS suffix used to build sandbox FQDNs. "+
@@ -312,6 +324,20 @@ func applyEnvDefaults(c *Config, lookup LookupEnvFunc) {
 	}
 	if v, ok := lookup(EnvKubeconfig); ok && v != "" {
 		c.Kubeconfig = v
+	}
+	if v, ok := lookup(EnvTLSMinVersion); ok && v != "" {
+		c.TLSMinVersion = v
+	}
+	if v, ok := lookup(EnvTLSCipherSuites); ok && v != "" {
+		parts := strings.Split(v, ",")
+		var out []string
+		for _, p := range parts {
+			p = strings.TrimSpace(p)
+			if p != "" {
+				out = append(out, p)
+			}
+		}
+		c.TLSCipherSuites = out
 	}
 }
 

--- a/sandbox-router/tlsutil/config.go
+++ b/sandbox-router/tlsutil/config.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 
+	inttls "sigs.k8s.io/agent-sandbox/internal/tlsutil"
 	"sigs.k8s.io/agent-sandbox/sandbox-router/config"
 )
 
@@ -37,10 +38,31 @@ func BuildServerTLS(cfg *config.Config, reloader *CertReloader) (*tls.Config, er
 		return nil, errors.New("reloader must not be nil")
 	}
 
+	minVersion := uint16(tls.VersionTLS12)
+	if cfg.TLSMinVersion != "" {
+		v, err := inttls.ParseTLSVersion(cfg.TLSMinVersion)
+		if err != nil {
+			return nil, fmt.Errorf("parse TLS min version: %w", err)
+		}
+		minVersion = v
+	}
+
 	tc := &tls.Config{
-		MinVersion:     tls.VersionTLS12,
+		MinVersion:     minVersion,
 		GetCertificate: reloader.GetCertificate,
 		NextProtos:     []string{"h2", "http/1.1"},
+	}
+
+	// Always parse so a typo fails at startup even when TLS 1.3 would
+	// ignore CipherSuites (Go does not let callers configure TLS 1.3 suites).
+	if len(cfg.TLSCipherSuites) > 0 {
+		ids, err := inttls.ParseCipherSuites(cfg.TLSCipherSuites)
+		if err != nil {
+			return nil, fmt.Errorf("parse TLS cipher suites: %w", err)
+		}
+		if minVersion < tls.VersionTLS13 {
+			tc.CipherSuites = ids
+		}
 	}
 
 	switch cfg.MTLSMode {

--- a/sandbox-router/tlsutil/tls_profile_test.go
+++ b/sandbox-router/tlsutil/tls_profile_test.go
@@ -1,0 +1,119 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tlsutil
+
+import (
+	"crypto/tls"
+	"testing"
+
+	"sigs.k8s.io/agent-sandbox/sandbox-router/config"
+)
+
+func TestBuildServerTLS_TLSProfile(t *testing.T) {
+	reloader := newReloaderForTest(t)
+
+	t.Run("default MinVersion is TLS 1.2", func(t *testing.T) {
+		cfg := &config.Config{MTLSMode: config.MTLSOff}
+		tc, err := BuildServerTLS(cfg, reloader)
+		if err != nil {
+			t.Fatalf("BuildServerTLS: %v", err)
+		}
+		if tc.MinVersion != tls.VersionTLS12 {
+			t.Errorf("MinVersion: got %d, want %d", tc.MinVersion, tls.VersionTLS12)
+		}
+	})
+
+	t.Run("custom MinVersion", func(t *testing.T) {
+		cfg := &config.Config{
+			MTLSMode:      config.MTLSOff,
+			TLSMinVersion: "VersionTLS13",
+		}
+		tc, err := BuildServerTLS(cfg, reloader)
+		if err != nil {
+			t.Fatalf("BuildServerTLS: %v", err)
+		}
+		if tc.MinVersion != tls.VersionTLS13 {
+			t.Errorf("MinVersion: got %d, want %d", tc.MinVersion, tls.VersionTLS13)
+		}
+	})
+
+	t.Run("invalid MinVersion", func(t *testing.T) {
+		cfg := &config.Config{
+			MTLSMode:      config.MTLSOff,
+			TLSMinVersion: "bogus",
+		}
+		_, err := BuildServerTLS(cfg, reloader)
+		if err == nil {
+			t.Fatalf("expected error for invalid min version")
+		}
+	})
+
+	t.Run("cipher suites applied", func(t *testing.T) {
+		cfg := &config.Config{
+			MTLSMode: config.MTLSOff,
+			TLSCipherSuites: []string{
+				"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+				"TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+			},
+		}
+		tc, err := BuildServerTLS(cfg, reloader)
+		if err != nil {
+			t.Fatalf("BuildServerTLS: %v", err)
+		}
+		if len(tc.CipherSuites) != 2 {
+			t.Fatalf("CipherSuites: got %d entries, want 2", len(tc.CipherSuites))
+		}
+	})
+
+	t.Run("cipher suites ignored for TLS 1.3", func(t *testing.T) {
+		cfg := &config.Config{
+			MTLSMode:      config.MTLSOff,
+			TLSMinVersion: "VersionTLS13",
+			TLSCipherSuites: []string{
+				"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+			},
+		}
+		tc, err := BuildServerTLS(cfg, reloader)
+		if err != nil {
+			t.Fatalf("BuildServerTLS: %v", err)
+		}
+		if len(tc.CipherSuites) != 0 {
+			t.Errorf("CipherSuites should be empty for TLS 1.3, got %d", len(tc.CipherSuites))
+		}
+	})
+
+	t.Run("invalid cipher suite", func(t *testing.T) {
+		cfg := &config.Config{
+			MTLSMode:        config.MTLSOff,
+			TLSCipherSuites: []string{"TLS_BOGUS"},
+		}
+		_, err := BuildServerTLS(cfg, reloader)
+		if err == nil {
+			t.Fatalf("expected error for invalid cipher suite")
+		}
+	})
+
+	t.Run("invalid cipher suite rejected even with TLS 1.3", func(t *testing.T) {
+		cfg := &config.Config{
+			MTLSMode:        config.MTLSOff,
+			TLSMinVersion:   "VersionTLS13",
+			TLSCipherSuites: []string{"TLS_BOGUS"},
+		}
+		_, err := BuildServerTLS(cfg, reloader)
+		if err == nil {
+			t.Fatalf("expected error for invalid cipher suite even with TLS 1.3")
+		}
+	})
+}


### PR DESCRIPTION
The controller and sandbox-router previously offered no way to tune TLS parameters, requiring consumers to accept the compiled defaults.

Controller: add --metrics-secure-serving, --metrics-cert-dir, --tls-min-version, and --tls-cipher-suites flags to configure the metrics server's TLS settings. The metrics endpoint remains plain HTTP by default; enabling secure serving is opt-in.

Sandbox-router: add --tls-min-version and --tls-cipher-suites flags (also settable via TLS_MIN_VERSION / TLS_CIPHER_SUITES env vars and the config file). The existing TLS 1.2 minimum default is preserved when the flags are unset.

A downstream operator or platform integrator can inject profile-derived values via Deployment args or environment variables without changes to this project.

#### What this PR does / why we need it:
<!-- Provide a clear and concise description of the changes in this PR. -->

#### Which issue(s) this PR is related to:
<!--
To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.

Examples:
Fixes #<issue number>
Ref <issue link> (issue in a different repository)
-->

#### Release Note
<!--
If this PR requires a release note (for features, fixes, or breaking changes), please add it below.
If no release note is needed, you can leave this block empty or write "NONE".

Note: Automated release notes are generated by Gemini using the PR description in the first section.
Please ensure that description is clear and comprehensive.
For breaking changes, ensure you describe the required actions clearly and the PR is labeled with `release-note-action-required`.
-->
```release-note
```

<!--
=======================================================================
⚠️ CONTRIBUTOR NOTICES (Please read before submitting)
By submitting this PR, you acknowledge our [Contributing Guidelines](https://github.com/kubernetes-sigs/agent-sandbox/blob/main/CONTRIBUTING.md):

* CLA REQUIRED: You must sign the Kubernetes CLA before your PR can be reviewed.
* AI REVIEWS:
  * We use Copilot and CodeRabbit for initial reviews. Do NOT click "Commit suggestion" in the GitHub UI, as AI bots cannot sign the CLA and will block your PR. Please apply suggestions locally instead.
  * Once automated reviews finish the first pass, please resolve their comments so the PR can be labeled `ready-for-review` for maintainers!
* PR TAKEOVERS: To speed up delivery, maintainers may push final changes and directly merge your PR if it is close to completion.
* STALE POLICY: PRs inactive for 30 days are marked stale and closed 15 days later.
=======================================================================
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional HTTPS serving for controller metrics.
  * Added configurable minimum TLS versions and cipher suites for metrics and router traffic.
  * Added command-line flags, environment variables, and YAML settings for TLS configuration.
  * TLS 1.2 remains the default; cipher suites are not applied to TLS 1.3 and later.
  * Invalid TLS versions or cipher suites are rejected with configuration errors.

* **Documentation**
  * Added configuration guidance and examples for metrics TLS and router TLS profiles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->