### PR TITLE
feat(clients/ts): support automatic sandbox expiration

### DIFF
--- a/clients/typescript/agentic-sandbox-client/README.md
+++ b/clients/typescript/agentic-sandbox-client/README.md
@@ -23,3 +23,26 @@ npm run build
 ```
 
 See [src/index.ts](src/index.ts) for the full set of exports.
+
+## Automatic expiration
+
+Set `shutdownAfterSeconds` when creating a sandbox to have the controller delete
+its claim and sandbox after the requested lifetime, even if the client process
+exits before cleaning up:
+
+```typescript
+import { SandboxClient } from "./dist/index.js";
+
+const client = new SandboxClient();
+const sandbox = await client.createSandbox("my-warm-pool", "default", {
+  shutdownAfterSeconds: 300,
+});
+```
+
+The lifetime starts at the `createSandbox` call and includes provisioning time.
+The option sets an absolute `spec.lifecycle.shutdownTime` and
+`shutdownPolicy: "Delete"` on the claim, matching the Python SDK's
+`shutdown_after_seconds`. It must be a positive integer that produces a valid
+RFC3339 deadline; invalid values reject with `SandboxError` before provisioning.
+Omitting it leaves expiration unset. Continue to call `sandbox.close()` when work
+finishes; expiration provides a fallback if the client cannot clean up.

--- a/clients/typescript/agentic-sandbox-client/README.md
+++ b/clients/typescript/agentic-sandbox-client/README.md
@@ -41,7 +41,7 @@ const sandbox = await client.createSandbox("my-warm-pool", "default", {
 
 The lifetime starts at the `createSandbox` call and includes provisioning time.
 The option sets an absolute `spec.lifecycle.shutdownTime` and
-`shutdownPolicy: "Delete"` on the claim, matching the Python SDK's
+`spec.lifecycle.shutdownPolicy: "Delete"` on the claim, matching the Python SDK's
 `shutdown_after_seconds`. It must be a positive integer that produces a valid
 RFC3339 deadline; invalid values reject with `SandboxError` before provisioning.
 Omitting it leaves expiration unset. Continue to call `sandbox.close()` when work

--- a/clients/typescript/agentic-sandbox-client/src/__tests__/sandbox-client.test.ts
+++ b/clients/typescript/agentic-sandbox-client/src/__tests__/sandbox-client.test.ts
@@ -211,6 +211,7 @@ describe("SandboxClient (registry)", () => {
       expect(createArgs.plural).toBe(CLAIM_PLURAL_NAME);
       expect(createArgs.namespace).toBe("default");
       expect(createArgs.body.spec.warmPoolRef.name).toBe("test-template");
+      expect(createArgs.body.spec).not.toHaveProperty("lifecycle");
 
       // Verify two watches were used
       expect(mockWatchFn).toHaveBeenCalledTimes(2);
@@ -256,6 +257,63 @@ describe("SandboxClient (registry)", () => {
         env: "test",
         team: "infra",
       });
+    });
+
+    it("sets a deletion deadline from the create call, preserving namespace and labels", async () => {
+      vi.useFakeTimers();
+      try {
+        vi.setSystemTime(new Date("2026-09-10T12:00:00.000Z"));
+        mockCreateNamespacedCustomObject.mockResolvedValueOnce({});
+        mockSandboxReadyFlow("sandbox-expiring");
+
+        const client = new SandboxClient();
+        const pending = client.createSandbox("tpl", "prod", {
+          shutdownAfterSeconds: 60,
+          labels: { team: "infra" },
+        });
+        // Time spent provisioning must not extend the requested lifetime.
+        vi.setSystemTime(new Date("2026-09-10T12:00:30.000Z"));
+        await pending;
+
+        const createArgs = mockCreateNamespacedCustomObject.mock.calls[0][0];
+        expect(createArgs.namespace).toBe("prod");
+        expect(createArgs.body.metadata.labels).toEqual({ team: "infra" });
+        expect(createArgs.body.spec).toEqual({
+          warmPoolRef: { name: "tpl" },
+          lifecycle: {
+            shutdownTime: "2026-09-10T12:01:00.000Z",
+            shutdownPolicy: "Delete",
+          },
+        });
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it.each([
+      ["zero", 0],
+      ["negative", -1],
+      ["fractional", 0.5],
+      ["NaN", Number.NaN],
+      ["Infinity", Number.POSITIVE_INFINITY],
+      ["-Infinity", Number.NEGATIVE_INFINITY],
+      ["outside the Date range", Number.MAX_VALUE],
+      ["beyond RFC3339's four-digit year", 253402300800],
+      ["string", "60"],
+      ["null", null],
+    ])("rejects invalid shutdownAfterSeconds (%s) before provisioning", async (_label, seconds) => {
+      mockSandboxReadyFlow("sandbox-invalid-ttl");
+
+      const client = new SandboxClient();
+      await expect(
+        client.createSandbox("tpl", "default", {
+          // JavaScript callers do not have TypeScript's input checks.
+          shutdownAfterSeconds: seconds as number,
+        }),
+      ).rejects.toThrow(SandboxError);
+      expect(mockCreateNamespacedCustomObject).not.toHaveBeenCalled();
+      expect(mockDeleteNamespacedCustomObject).not.toHaveBeenCalled();
+      expect(mockWatchFn).not.toHaveBeenCalled();
     });
 
     it("throws when warmpool is empty", async () => {

--- a/clients/typescript/agentic-sandbox-client/src/sandbox-client.ts
+++ b/clients/typescript/agentic-sandbox-client/src/sandbox-client.ts
@@ -304,6 +304,26 @@ export class SandboxClient {
       );
     }
 
+    let shutdownTime: string | undefined;
+    if (opts?.shutdownAfterSeconds !== undefined) {
+      const seconds = opts.shutdownAfterSeconds;
+      if (!Number.isInteger(seconds) || seconds <= 0) {
+        throw new SandboxError(
+          `shutdownAfterSeconds must be a positive integer, got: ${seconds}`,
+        );
+      }
+      // Fix the deadline before any asynchronous provisioning work. JavaScript
+      // permits dates beyond RFC3339's four-digit year range.
+      const deadline = new Date(Date.now() + seconds * 1000);
+      if (
+        Number.isNaN(deadline.getTime()) ||
+        deadline.getUTCFullYear() > 9999
+      ) {
+        throw new SandboxError(`shutdownAfterSeconds is too large: ${seconds}`);
+      }
+      shutdownTime = deadline.toISOString();
+    }
+
     // Empty string normalizes to defaultNamespace (matches Go client behaviour).
     const ns = namespace || this.defaultNamespace;
     const claimName = `sandbox-claim-${crypto.randomBytes(4).toString("hex")}`;
@@ -321,6 +341,7 @@ export class SandboxClient {
       warmpool,
       ns,
       opts,
+      shutdownTime,
     ).finally(() => {
       this.attaching.delete(key);
       this.provisioning.delete(key);
@@ -340,6 +361,7 @@ export class SandboxClient {
     warmpool: string,
     ns: string,
     opts?: CreateSandboxOptions,
+    shutdownTime?: string,
   ): Promise<Sandbox> {
     const sandboxReadyTimeout =
       opts?.sandboxReadyTimeout ?? this.defaultSandboxReadyTimeout;
@@ -370,6 +392,7 @@ export class SandboxClient {
         traceContextStr,
         sandboxTracer,
         sandboxTracingManager?.parentContext,
+        shutdownTime,
       );
       // deleteAll() may have swept this key while the claim was being created;
       // it could not delete a claim the apiserver had not accepted yet, so fail
@@ -933,6 +956,7 @@ export class SandboxClient {
     traceContextStr: string = "",
     tracer: Tracer | null = null,
     parentContext?: unknown,
+    shutdownTime?: string,
   ): Promise<void> {
     if (labels) {
       validateLabels(labels);
@@ -960,6 +984,9 @@ export class SandboxClient {
         },
         spec: {
           warmPoolRef: { name: warmpool },
+          ...(shutdownTime
+            ? { lifecycle: { shutdownTime, shutdownPolicy: "Delete" } }
+            : {}),
         },
       };
 

--- a/clients/typescript/agentic-sandbox-client/src/types.ts
+++ b/clients/typescript/agentic-sandbox-client/src/types.ts
@@ -46,8 +46,10 @@ export interface CreateSandboxOptions {
   labels?: Record<string, string>;
   /**
    * Delete the claim and its sandbox after this many seconds, measured from
-   * the createSandbox call (including provisioning time). Must be a positive
-   * integer that produces a valid RFC3339 deadline. Omit to leave expiration unset.
+   * the createSandbox call (including provisioning time). Sets the claim's
+   * `spec.lifecycle.shutdownTime` to that absolute deadline and its
+   * `spec.lifecycle.shutdownPolicy` to `"Delete"`. Must be a positive integer
+   * that produces a valid RFC3339 deadline. Omit to leave expiration unset.
    */
   shutdownAfterSeconds?: number;
 }

--- a/clients/typescript/agentic-sandbox-client/src/types.ts
+++ b/clients/typescript/agentic-sandbox-client/src/types.ts
@@ -44,4 +44,10 @@ export interface Logger {
 export interface CreateSandboxOptions {
   sandboxReadyTimeout?: number;
   labels?: Record<string, string>;
+  /**
+   * Delete the claim and its sandbox after this many seconds, measured from
+   * the createSandbox call (including provisioning time). Must be a positive
+   * integer that produces a valid RFC3339 deadline. Omit to leave expiration unset.
+   */
+  shutdownAfterSeconds?: number;
 }


### PR DESCRIPTION
#### What this PR does / why we need it:

TypeScript callers cannot currently set a controller-enforced lifetime for a sandbox. If the client exits before cleanup, its claim can remain indefinitely.

Add optional `shutdownAfterSeconds` to `CreateSandboxOptions`. It sets the claim's absolute `spec.lifecycle.shutdownTime` and `shutdownPolicy: "Delete"`, matching the Python SDK. The lifetime starts at the creation call, including provisioning time. Omitting the option preserves existing behavior.

Invalid durations, including timestamps outside RFC3339's year range, fail before Kubernetes requests. Tests cover the emitted claim, unchanged behavior without the option, and invalid inputs.

Validation:
- All 137 TypeScript unit tests pass; the 11 new tests failed before implementation.
- Type checking, Biome, and the TypeScript build pass.
- Repository builds, Go/API lint, Go/Python unit suites, TOC verification, and OLM verification pass. `make all` hit a local Go compiler/GOROOT mismatch in the nested OLM unit module; that module passed when rerun with `GOROOT` unset and `GOTOOLCHAIN=go1.26.4`, followed by the remaining verification targets.

#### Which issue(s) this PR is related to:

Ref https://github.com/kubernetes-sigs/agent-sandbox/issues/977 — implements only the `shutdownAfterSeconds` parity item.

Addresses the missing expiration option identified in https://github.com/kubernetes-sigs/agent-sandbox/pull/976#discussion_r3461387460.

#### Release Note

```release-note
The TypeScript SDK now accepts shutdownAfterSeconds when creating a sandbox, allowing the controller to delete the claim and sandbox after the requested lifetime even if the client exits without cleaning up.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an optional automatic expiration setting when creating a sandbox.
  - Sandboxes can be configured to shut down and be deleted after a specified positive number of seconds.
  - Expiration is calculated from the sandbox creation request time.
  - Invalid expiration values are rejected before sandbox creation.
  - Sandboxes without an expiration setting continue to be created without an automatic shutdown deadline.

- **Documentation**
  - Added usage guidance, lifecycle behavior, validation details, and examples for automatic expiration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->