### PR TITLE
feat(clients/ts): add label selectors to listAllSandboxes

### DIFF
--- a/clients/typescript/agentic-sandbox-client/README.md
+++ b/clients/typescript/agentic-sandbox-client/README.md
@@ -23,3 +23,27 @@ npm run build
 ```
 
 See [src/index.ts](src/index.ts) for the full set of exports.
+
+## Listing sandboxes
+
+With Kubernetes credentials configured and permission to list SandboxClaims, run
+the following from this package directory after building locally:
+
+```ts
+import { SandboxClient } from "./dist/index.js";
+
+const client = new SandboxClient({ namespace: "default" });
+
+const allClaims = await client.listAllSandboxes("default");
+const appClaims = await client.listAllSandboxes("default", "app=my-agent");
+const devClaims = await client.listAllSandboxes(
+  undefined,
+  "env in (dev,test),!disabled",
+);
+```
+
+The optional second argument is a Kubernetes label selector for
+`SandboxClaim.metadata.labels` (set through `createSandbox`'s `labels` option),
+not Pod labels. Omitting the selector or passing an empty string lists all claims
+in the namespace. Omitting the namespace or passing `undefined` or an empty string
+uses the client's configured default namespace.

--- a/clients/typescript/agentic-sandbox-client/src/__tests__/sandbox-client.test.ts
+++ b/clients/typescript/agentic-sandbox-client/src/__tests__/sandbox-client.test.ts
@@ -667,7 +667,8 @@ describe("SandboxClient (registry)", () => {
       expect(await client.listAllSandboxes("team-b", labelSelector)).toEqual([
         "sandbox-claim-aaa",
       ]);
-      expect(mockListNamespacedCustomObject).toHaveBeenCalledExactlyOnceWith({
+      expect(mockListNamespacedCustomObject).toHaveBeenCalledOnce();
+      expect(mockListNamespacedCustomObject.mock.calls[0][0]).toStrictEqual({
         group: CLAIM_API_GROUP,
         version: CLAIM_API_VERSION,
         namespace: "team-b",
@@ -699,7 +700,8 @@ describe("SandboxClient (registry)", () => {
 
       await client.listAllSandboxes(namespace, "app=my-agent");
 
-      expect(mockListNamespacedCustomObject).toHaveBeenCalledExactlyOnceWith({
+      expect(mockListNamespacedCustomObject).toHaveBeenCalledOnce();
+      expect(mockListNamespacedCustomObject.mock.calls[0][0]).toStrictEqual({
         group: CLAIM_API_GROUP,
         version: CLAIM_API_VERSION,
         namespace: "team-a",

--- a/clients/typescript/agentic-sandbox-client/src/__tests__/sandbox-client.test.ts
+++ b/clients/typescript/agentic-sandbox-client/src/__tests__/sandbox-client.test.ts
@@ -633,7 +633,7 @@ describe("SandboxClient (registry)", () => {
       const names = await client.listAllSandboxes("default");
 
       expect(names).toEqual(["sandbox-claim-aaa", "sandbox-claim-bbb"]);
-      expect(mockListNamespacedCustomObject).toHaveBeenCalledWith({
+      expect(mockListNamespacedCustomObject.mock.calls[0][0]).toStrictEqual({
         group: CLAIM_API_GROUP,
         version: CLAIM_API_VERSION,
         namespace: "default",
@@ -645,6 +645,109 @@ describe("SandboxClient (registry)", () => {
       mockListNamespacedCustomObject.mockResolvedValueOnce({ items: [] });
       const client = new SandboxClient();
       expect(await client.listAllSandboxes()).toEqual([]);
+      expect(mockListNamespacedCustomObject.mock.calls[0][0]).toStrictEqual({
+        group: CLAIM_API_GROUP,
+        version: CLAIM_API_VERSION,
+        namespace: "default",
+        plural: CLAIM_PLURAL_NAME,
+      });
+    });
+
+    it.each([
+      "app=my-agent",
+      "env in (dev,test),!disabled",
+      "team",
+      "",
+    ])("passes label selector %j to Kubernetes unchanged", async (labelSelector) => {
+      mockListNamespacedCustomObject.mockResolvedValueOnce({
+        items: [{ metadata: { name: "sandbox-claim-aaa" } }],
+      });
+      const client = new SandboxClient({ namespace: "team-a" });
+
+      expect(await client.listAllSandboxes("team-b", labelSelector)).toEqual([
+        "sandbox-claim-aaa",
+      ]);
+      expect(mockListNamespacedCustomObject).toHaveBeenCalledExactlyOnceWith({
+        group: CLAIM_API_GROUP,
+        version: CLAIM_API_VERSION,
+        namespace: "team-b",
+        plural: CLAIM_PLURAL_NAME,
+        labelSelector,
+      });
+    });
+
+    it("omits an undefined label selector", async () => {
+      mockListNamespacedCustomObject.mockResolvedValueOnce({ items: [] });
+      const client = new SandboxClient();
+
+      await client.listAllSandboxes("team-a", undefined);
+
+      expect(mockListNamespacedCustomObject.mock.calls[0][0]).toStrictEqual({
+        group: CLAIM_API_GROUP,
+        version: CLAIM_API_VERSION,
+        namespace: "team-a",
+        plural: CLAIM_PLURAL_NAME,
+      });
+    });
+
+    it.each([
+      undefined,
+      "",
+    ])("uses the configured default namespace when namespace is %j", async (namespace) => {
+      mockListNamespacedCustomObject.mockResolvedValueOnce({ items: [] });
+      const client = new SandboxClient({ namespace: "team-a" });
+
+      await client.listAllSandboxes(namespace, "app=my-agent");
+
+      expect(mockListNamespacedCustomObject).toHaveBeenCalledExactlyOnceWith({
+        group: CLAIM_API_GROUP,
+        version: CLAIM_API_VERSION,
+        namespace: "team-a",
+        plural: CLAIM_PLURAL_NAME,
+        labelSelector: "app=my-agent",
+      });
+    });
+
+    it.each([
+      { response: { items: [] }, expected: [] },
+      { response: {}, expected: [] },
+      {
+        response: {
+          items: [
+            { metadata: { name: "sandbox-claim-bbb" } },
+            {},
+            { metadata: {} },
+            { metadata: { name: "" } },
+            { metadata: { name: "sandbox-claim-aaa" } },
+          ],
+        },
+        expected: ["sandbox-claim-bbb", "sandbox-claim-aaa"],
+      },
+    ])("extracts claim names from $response with a selector", async ({
+      response,
+      expected,
+    }) => {
+      mockListNamespacedCustomObject.mockResolvedValueOnce(response);
+      const client = new SandboxClient();
+
+      expect(await client.listAllSandboxes("default", "app=my-agent")).toEqual(
+        expected,
+      );
+      expect(mockListNamespacedCustomObject.mock.calls[0][0]).toHaveProperty(
+        "labelSelector",
+        "app=my-agent",
+      );
+    });
+
+    it("propagates the original Kubernetes error with a selector", async () => {
+      const error = new Error("Forbidden");
+      mockListNamespacedCustomObject.mockRejectedValueOnce(error);
+      const client = new SandboxClient();
+
+      await expect(
+        client.listAllSandboxes("default", "app=my-agent"),
+      ).rejects.toBe(error);
+      expect(mockListNamespacedCustomObject).toHaveBeenCalledOnce();
     });
   });
 

--- a/clients/typescript/agentic-sandbox-client/src/sandbox-client.ts
+++ b/clients/typescript/agentic-sandbox-client/src/sandbox-client.ts
@@ -645,15 +645,21 @@ export class SandboxClient {
   }
 
   /**
-   * Lists all SandboxClaim names in the cluster for the given namespace.
+   * Lists SandboxClaim names, optionally filtered by a Kubernetes label selector.
+   * The selector matches SandboxClaim metadata.labels.
+   * Uses the client's default namespace when namespace is omitted or empty.
    */
-  async listAllSandboxes(namespace?: string): Promise<string[]> {
+  async listAllSandboxes(
+    namespace?: string,
+    labelSelector?: string,
+  ): Promise<string[]> {
     const ns = namespace || this.defaultNamespace;
     const response = await this.customObjectsApi.listNamespacedCustomObject({
       group: CLAIM_API_GROUP,
       version: CLAIM_API_VERSION,
       namespace: ns,
       plural: CLAIM_PLURAL_NAME,
+      ...(labelSelector !== undefined ? { labelSelector } : {}),
     });
     const list = response as {
       items?: Array<{ metadata?: { name?: string } }>;


### PR DESCRIPTION
#### What this PR does / why we need it:

TypeScript callers currently have to list every SandboxClaim in a namespace, even when they only need claims with specific labels.
Add an optional `labelSelector` argument to `SandboxClient.listAllSandboxes`, matching the Python SDK while preserving the existing positional namespace argument. The selector filters SandboxClaim labels through the Kubernetes list API.
Includes regression tests and a short client README usage example.


#### Which issue(s) this PR is related to:

Related to #977.

#### Testing 
  - TypeScript SDK: 137 tests passed; typecheck, build, and Biome check passed.
  - Docker/kind: 11 checks passed against the actual SandboxClaim API.
  - Repository generation, builds, Go/API lint, 1,576 Go tests with the race detector, TOC verification, and OLM manifest verification passed across multiple runs.
  - All 14 Python suites checked: 1,158 tests and 8 subtests passed, with 1 optional-gRPC skip, including an SDK rerun after correcting the proxy environment. 
  - Full runtime/controller e2e tests were not run.
 

#### Release Note

```release-note
The TypeScript SandboxClient.listAllSandboxes method now accepts an optional labelSelector argument to filter SandboxClaims by their labels. 
```

<!--
=======================================================================
⚠️ CONTRIBUTOR NOTICES (Please read before submitting)
By submitting this PR, you acknowledge our [Contributing Guidelines](https://github.com/kubernetes-sigs/agent-sandbox/blob/main/CONTRIBUTING.md):

* CLA REQUIRED: You must sign the Kubernetes CLA before your PR can be reviewed.
* AI REVIEWS:
  * We use Copilot and CodeRabbit for initial reviews. Do NOT click "Commit suggestion" in the GitHub UI, as AI bots cannot sign the CLA and will block your PR. Please apply suggestions locally instead.
  * Once automated reviews finish the first pass, please resolve their comments so the PR can be labeled `ready-for-review` for maintainers!
* PR TAKEOVERS: To speed up delivery, maintainers may push final changes and directly merge your PR if it is close to completion.
* STALE POLICY: PRs inactive for 30 days are marked stale and closed 15 days later.
=======================================================================
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional label-selector filtering when listing sandboxes.
  * Sandbox listings now use the client’s configured namespace when none is provided.
  * Added support for automatically shutting down and deleting sandboxes after a specified duration.
* **Documentation**
  * Added usage examples and guidance for listing sandboxes with label selectors.
* **Tests**
  * Expanded coverage for label selectors, namespace fallback, shutdown configuration, varied responses, and error propagation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->