### PR TITLE
Add unit tests for seven examples with untested security/state logic

### DIFF
--- a/dev/tools/test-unit
+++ b/dev/tools/test-unit
@@ -71,6 +71,36 @@ PYTHON_TEST_SUITES = [
         "requirements": "requirements.txt",
     },
     {
+        "name": "firecracker-sandbox",
+        "dir": os.path.join("examples", "firecracker-sandbox"),
+        "requirements": "requirements.txt",
+        "extra_packages": ["httpx"],
+    },
+    {
+        "name": "gke-swap-python-density",
+        # parse_telemetry.py is stdlib-only (csv, json), so the test needs no
+        # requirements.txt -- just pytest, installed unconditionally below.
+        "dir": os.path.join("examples", "gke-swap", "python-density"),
+    },
+    {
+        "name": "hermes-agents-as-a-service",
+        "dir": os.path.join("examples", "hermes-agents-as-a-service", "gateway"),
+        "requirements": "requirements.txt",
+    },
+    {
+        "name": "kata-aks-agent",
+        "dir": os.path.join("examples", "kata-aks", "agent"),
+        "requirements": "requirements.txt",
+    },
+    {
+        "name": "n8n-mcp",
+        # server.py's deps are declared inline in its Dockerfile rather than a
+        # requirements.txt; httpx is additionally needed for FastAPI's
+        # TestClient, which the Dockerfile has no reason to install.
+        "dir": os.path.join("examples", "n8n-mcp", "source"),
+        "extra_packages": ["fastapi", "httpx"],
+    },
+    {
         "name": "agent-sandbox-rl",
         "dir": os.path.join("examples", "agent-sandbox-rl"),
         # Editable installs (in order): the in-repo SDK first (so we don't depend
@@ -243,6 +273,14 @@ def run_python_tests(repo_root, artifact_dir):
             # Force-reinstall kubernetes_asyncio after kubernetes to restore correct files.
             subprocess.check_call(
                 [venv_pip, "install", "--quiet", "--force-reinstall", "kubernetes_asyncio"], env=env)
+
+        # Packages the suite needs only for testing (e.g. httpx for FastAPI's
+        # TestClient) and that therefore don't belong in the example's own
+        # requirements.txt, which mirrors what its Dockerfile installs.
+        extra_packages = suite.get("extra_packages", [])
+        if extra_packages:
+            subprocess.check_call(
+                [venv_pip, "install", "--quiet", *extra_packages], env=env)
 
         subprocess.check_call(
             [venv_pip, "install", "--quiet", "pytest"], env=env)

--- a/examples/firecracker-sandbox/test_main.py
+++ b/examples/firecracker-sandbox/test_main.py
@@ -1,0 +1,349 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Unit tests for the firecracker-sandbox runtime.
+
+main.py runs inside the sandbox pod as a FastAPI server; these tests
+exercise its endpoints in-process via FastAPI's TestClient, with
+subprocess.Popen mocked for /exec. No kind cluster, Firecracker microVM, or
+container build is needed.
+"""
+
+import os
+import signal
+import subprocess
+import tempfile
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+from fastapi.testclient import TestClient
+
+# main.py creates WORKSPACE (default "/workspace") at import time, which
+# isn't writable outside a container. Point it at a scratch directory before
+# import; the autouse `workspace` fixture below then redirects main.WORKSPACE
+# to a fresh tmp_path for every individual test.
+os.environ.setdefault("SANDBOX_WORKSPACE", tempfile.mkdtemp(prefix="firecracker-sandbox-test-"))
+
+import main  # noqa: E402
+from main import app  # noqa: E402
+
+client = TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def workspace(tmp_path, monkeypatch):
+    """Redirect WORKSPACE to a scratch directory for every test.
+
+    main.WORKSPACE is computed once at import time from
+    SANDBOX_WORKSPACE/"/workspace", which would otherwise point outside the
+    test sandbox (and doesn't exist) when tests run outside a container.
+    """
+    monkeypatch.setattr(main, "WORKSPACE", tmp_path)
+    main._user_env.clear()
+    return tmp_path
+
+
+def test_health_returns_204():
+    response = client.get("/health")
+    assert response.status_code == 204
+
+
+def test_root():
+    response = client.get("/")
+    assert response.status_code == 200
+    assert response.json() == {"runtime": "firecracker-sandbox", "version": "0.1.0"}
+
+
+def test_metrics_returns_a_timestamp():
+    response = client.get("/metrics")
+    assert response.status_code == 200
+    assert "timestamp" in response.json()
+
+
+# --- _safe_path (workspace escape guard) ------------------------------------
+
+class TestSafePath:
+    def test_relative_path_inside_workspace(self, workspace):
+        resolved = main._safe_path("sub/file.txt")
+        assert resolved == (workspace / "sub" / "file.txt").resolve()
+
+    def test_absolute_path_inside_workspace(self, workspace):
+        target = workspace / "abs.txt"
+        resolved = main._safe_path(str(target))
+        assert resolved == target.resolve()
+
+    def test_rejects_relative_traversal(self, workspace):
+        with pytest.raises(HTTPException) as exc_info:
+            main._safe_path("../escape.txt")
+        assert exc_info.value.status_code == 403
+
+    def test_rejects_traversal_hidden_inside_path(self, workspace):
+        with pytest.raises(HTTPException) as exc_info:
+            main._safe_path("sub/../../escape.txt")
+        assert exc_info.value.status_code == 403
+
+    def test_rejects_absolute_path_outside_workspace(self, workspace, tmp_path_factory):
+        outside = tmp_path_factory.mktemp("outside") / "escape.txt"
+        with pytest.raises(HTTPException) as exc_info:
+            main._safe_path(str(outside))
+        assert exc_info.value.status_code == 403
+
+    def test_rejects_symlink_escaping_workspace(self, workspace, tmp_path_factory):
+        outside_dir = tmp_path_factory.mktemp("outside")
+        target_file = outside_dir / "secret.txt"
+        target_file.write_text("data")
+        link = workspace / "escape-link"
+        link.symlink_to(target_file)
+
+        with pytest.raises(HTTPException) as exc_info:
+            main._safe_path("escape-link")
+        assert exc_info.value.status_code == 403
+
+    def test_allows_symlink_staying_inside_workspace(self, workspace):
+        real = workspace / "real.txt"
+        real.write_text("data")
+        link = workspace / "link.txt"
+        link.symlink_to(real)
+
+        assert main._safe_path("link.txt") == real.resolve()
+
+
+# --- /files (download / upload) ---------------------------------------------
+
+def test_download_file_returns_existing_file(workspace):
+    (workspace / "report.txt").write_text("contents")
+    response = client.get("/files", params={"path": "report.txt"})
+    assert response.status_code == 200
+    assert response.content == b"contents"
+
+
+def test_download_file_missing_returns_404(workspace):
+    response = client.get("/files", params={"path": "missing.txt"})
+    assert response.status_code == 404
+
+
+def test_download_file_rejects_path_traversal(workspace):
+    response = client.get("/files", params={"path": "../escape.txt"})
+    assert response.status_code == 403
+
+
+def test_upload_file_writes_to_workspace(workspace):
+    response = client.post(
+        "/files", data={"path": "hello.txt"}, files={"file": ("hello.txt", b"hello world")})
+
+    assert response.status_code == 200
+    assert (workspace / "hello.txt").read_bytes() == b"hello world"
+    assert response.json() == {"path": "hello.txt", "size": len(b"hello world")}
+
+
+def test_upload_file_creates_parent_directories(workspace):
+    response = client.post(
+        "/files", data={"path": "sub/dir/file.txt"}, files={"file": ("file.txt", b"nested")})
+
+    assert response.status_code == 200
+    assert (workspace / "sub" / "dir" / "file.txt").read_bytes() == b"nested"
+
+
+def test_upload_file_rejects_path_traversal(workspace):
+    response = client.post(
+        "/files", data={"path": "../escape.txt"}, files={"file": ("f.txt", b"pwned")})
+
+    assert response.status_code == 403
+    assert not (workspace.parent / "escape.txt").exists()
+
+
+# --- /init and /envs ---------------------------------------------------------
+
+def test_init_merges_envs_and_computes_skew(workspace, monkeypatch):
+    monkeypatch.setattr(main.time, "time", lambda: 1000.0)
+    # /init sets os.environ directly (not through monkeypatch), so clean up
+    # manually rather than relying on monkeypatch's teardown to catch it.
+    var = "FIRECRACKER_TEST_INIT_VAR"
+    try:
+        response = client.post("/init", json={"envs": {var: "bar"}, "timestamp": 990.0})
+        assert response.status_code == 200
+        body = response.json()
+        assert body["server_time"] == 1000.0
+        assert body["skew_seconds"] == 10.0
+        assert os.environ[var] == "bar"
+        assert main._user_env[var] == "bar"
+    finally:
+        os.environ.pop(var, None)
+
+
+def test_init_without_timestamp_has_no_skew(workspace):
+    response = client.post("/init", json={})
+    assert response.status_code == 200
+    assert response.json()["skew_seconds"] is None
+
+
+def test_envs_includes_injected_user_env(workspace):
+    main._user_env["FIRECRACKER_TEST_ENVS_VAR"] = "value"
+    try:
+        response = client.get("/envs")
+        assert response.status_code == 200
+        assert response.json()["FIRECRACKER_TEST_ENVS_VAR"] == "value"
+    finally:
+        main._user_env.pop("FIRECRACKER_TEST_ENVS_VAR", None)
+
+
+# --- /exec --------------------------------------------------------------------
+
+def _mock_process(mock_popen, stdout="", stderr="", returncode=0, pid=1234):
+    mock_process = MagicMock()
+    mock_process.communicate.return_value = (stdout, stderr)
+    mock_process.returncode = returncode
+    mock_process.pid = pid
+    mock_popen.return_value = mock_process
+    return mock_process
+
+
+@patch("main.subprocess.Popen")
+def test_exec_with_args_runs_without_shell(mock_popen, workspace):
+    _mock_process(mock_popen, stdout="hi\n", stderr="", returncode=0)
+
+    response = client.post("/exec", json={"cmd": "echo", "args": ["hi"]})
+
+    assert response.status_code == 200
+    assert response.json() == {"stdout": "hi\n", "stderr": "", "exit_code": 0}
+    called_args, called_kwargs = mock_popen.call_args
+    assert called_args[0] == ["echo", "hi"]
+    assert called_kwargs["shell"] is False
+    assert called_kwargs["cwd"] == str(workspace)
+    assert called_kwargs["start_new_session"] is True
+
+
+@patch("main.subprocess.Popen")
+def test_exec_without_args_runs_via_shell(mock_popen, workspace):
+    _mock_process(mock_popen, stdout="hi\nbye\n", stderr="", returncode=0)
+
+    response = client.post("/exec", json={"cmd": "echo hi && echo bye"})
+
+    assert response.status_code == 200
+    called_args, called_kwargs = mock_popen.call_args
+    assert called_args[0] == "echo hi && echo bye"
+    assert called_kwargs["shell"] is True
+
+
+@patch("main.subprocess.Popen")
+def test_exec_empty_args_list_still_runs_without_shell(mock_popen, workspace):
+    # args=[] is falsy but not None -- the handler branches on `is not None`,
+    # so an explicit empty list must still take the no-shell path.
+    _mock_process(mock_popen)
+
+    response = client.post("/exec", json={"cmd": "true", "args": []})
+
+    assert response.status_code == 200
+    called_args, called_kwargs = mock_popen.call_args
+    assert called_args[0] == ["true"]
+    assert called_kwargs["shell"] is False
+
+
+@patch("main.subprocess.Popen")
+def test_exec_merges_custom_env(mock_popen, workspace, monkeypatch):
+    monkeypatch.setenv("FIRECRACKER_TEST_PREEXISTING", "1")
+    _mock_process(mock_popen)
+
+    response = client.post("/exec", json={"cmd": "true", "args": [], "env": {"CUSTOM": "42"}})
+
+    assert response.status_code == 200
+    called_env = mock_popen.call_args.kwargs["env"]
+    assert called_env["CUSTOM"] == "42"
+    assert called_env["FIRECRACKER_TEST_PREEXISTING"] == "1"
+
+
+@patch("main.subprocess.Popen")
+def test_exec_rejects_cwd_that_is_not_a_directory(mock_popen, workspace):
+    (workspace / "file.txt").write_text("x")
+
+    response = client.post("/exec", json={"cmd": "pwd", "cwd": "file.txt"})
+
+    assert response.status_code == 400
+    mock_popen.assert_not_called()
+
+
+@patch("main.subprocess.Popen")
+def test_exec_rejects_cwd_path_traversal(mock_popen, workspace):
+    response = client.post("/exec", json={"cmd": "pwd", "cwd": "../escape"})
+
+    assert response.status_code == 403
+    mock_popen.assert_not_called()
+
+
+@patch("main.os.killpg")
+@patch("main.os.getpgid", return_value=4321)
+@patch("main.subprocess.Popen")
+def test_exec_timeout_kills_process_group(mock_popen, mock_getpgid, mock_killpg, workspace):
+    mock_process = _mock_process(mock_popen, pid=4321)
+    mock_process.communicate.side_effect = [
+        subprocess.TimeoutExpired(cmd="sleep infinity", timeout=1),
+        ("partial out", "partial err"),
+    ]
+
+    response = client.post("/exec", json={"cmd": "sleep infinity", "timeout": 1})
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["exit_code"] == -1
+    assert body["stdout"] == "partial out"
+    assert "[timeout after 1" in body["stderr"]
+    mock_getpgid.assert_called_once_with(4321)
+    mock_killpg.assert_called_once_with(4321, signal.SIGKILL)
+    assert mock_process.communicate.call_count == 2
+
+
+@patch("main.os.killpg", side_effect=ProcessLookupError)
+@patch("main.os.getpgid", return_value=4321)
+@patch("main.subprocess.Popen")
+def test_exec_timeout_survives_process_group_already_gone(mock_popen, mock_getpgid, mock_killpg, workspace):
+    # The process can exit between TimeoutExpired and killpg (e.g. it
+    # finished right at the deadline); killpg racing a gone pgid must not
+    # fail the request.
+    mock_process = _mock_process(mock_popen, pid=4321)
+    mock_process.communicate.side_effect = [
+        subprocess.TimeoutExpired(cmd="sleep infinity", timeout=1),
+        ("", ""),
+    ]
+
+    response = client.post("/exec", json={"cmd": "sleep infinity", "timeout": 1})
+
+    assert response.status_code == 200
+    assert response.json()["exit_code"] == -1
+
+
+@patch("main.subprocess.Popen", side_effect=FileNotFoundError("no such file"))
+def test_exec_missing_binary_returns_127(mock_popen, workspace):
+    response = client.post("/exec", json={"cmd": "no-such-binary", "args": []})
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["exit_code"] == 127
+    assert "no such file" in body["stderr"]
+
+
+@patch("main.subprocess.Popen", side_effect=OSError("boom"))
+def test_exec_unexpected_error_returns_1(mock_popen, workspace):
+    response = client.post("/exec", json={"cmd": "true", "args": []})
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["exit_code"] == 1
+    assert "boom" in body["stderr"]
+
+
+def test_exec_rejects_timeout_out_of_bounds(workspace):
+    assert client.post("/exec", json={"cmd": "true", "timeout": 0}).status_code == 422
+    assert client.post("/exec", json={"cmd": "true", "timeout": 301}).status_code == 422

--- a/examples/gke-swap/python-density/test_parse_telemetry.py
+++ b/examples/gke-swap/python-density/test_parse_telemetry.py
@@ -1,0 +1,139 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Unit tests for the gke-swap python-density telemetry parser.
+
+parse_telemetry.process_telemetry() is a pure CSV -> JSON aggregation
+transform that runs after a density sweep; these tests exercise it directly
+against scratch CSV/JSON fixtures. No GKE cluster, Local SSD, or container
+build is needed.
+"""
+
+import json
+
+import pytest
+
+from parse_telemetry import process_telemetry
+
+
+def write_csv(path, rows):
+    with open(path, "w", encoding="utf-8") as f:
+        for row in rows:
+            f.write(",".join(row) + "\n")
+
+
+def write_json(path, data):
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(data, f)
+
+
+def test_raises_when_csv_missing(tmp_path):
+    json_path = tmp_path / "density.json"
+    write_json(json_path, {})
+
+    with pytest.raises(FileNotFoundError):
+        process_telemetry(str(tmp_path / "missing.csv"), str(json_path))
+
+
+def test_raises_when_json_missing(tmp_path):
+    csv_path = tmp_path / "telemetry.csv"
+    write_csv(csv_path, [["t", "node_memory_working_set_bytes", "1"]])
+
+    with pytest.raises(FileNotFoundError):
+        process_telemetry(str(csv_path), str(tmp_path / "missing.json"))
+
+
+def test_computes_peaks_and_deltas(tmp_path):
+    csv_path = tmp_path / "telemetry.csv"
+    json_path = tmp_path / "density.json"
+    write_csv(csv_path, [
+        ["t0", "node_memory_working_set_bytes", str(1 * 1024**3)],
+        ["t1", "node_memory_working_set_bytes", str(3 * 1024**3)],
+        ["t0", "host_swap_used_bytes", "0"],
+        ["t1", "host_swap_used_bytes", str(0.5 * 1024**3)],
+        ["t0", "kubelet_memory", "0"],
+        ["t1", "kubelet_memory", str(50 * 1024**2)],
+        ["t0", "runtime_memory", "0"],
+        ["t1", "runtime_memory", str(20 * 1024**2)],
+        ["t0", "host_mem_psi_waiting_seconds_total", "1.0"],
+        ["t1", "host_mem_psi_waiting_seconds_total", "1.25"],
+        ["t0", "host_io_psi_waiting_seconds_total", "2.0"],
+        ["t1", "host_io_psi_waiting_seconds_total", "2.5"],
+        ["t0", "host_cpu_psi_waiting_seconds_total", "0.1"],
+        ["t1", "host_cpu_psi_waiting_seconds_total", "0.4"],
+    ])
+    write_json(json_path, {"existing": "field"})
+
+    process_telemetry(str(csv_path), str(json_path))
+
+    data = json.loads(json_path.read_text())
+    assert data["existing"] == "field"  # original content is preserved, not replaced
+    peaks = data["node_telemetry_peaks"]
+    assert peaks == {
+        "peak_node_ram_gb": 3.0,
+        "net_ram_added_gb": 2.0,
+        "net_swap_added_gb": 0.5,
+        "kubelet_memory_mb": 50.0,
+        "containerd_memory_mb": 20.0,
+        "mem_psi_seconds": 0.25,
+        "io_psi_seconds": 0.5,
+        "cpu_psi_seconds": 0.3,
+    }
+
+
+def test_skips_rows_with_too_few_columns(tmp_path):
+    csv_path = tmp_path / "telemetry.csv"
+    json_path = tmp_path / "density.json"
+    write_csv(csv_path, [
+        ["t0", "node_memory_working_set_bytes"],  # only 2 columns, must be skipped
+        ["t1", "node_memory_working_set_bytes", str(2 * 1024**3)],
+    ])
+    write_json(json_path, {})
+
+    process_telemetry(str(csv_path), str(json_path))
+
+    peaks = json.loads(json_path.read_text())["node_telemetry_peaks"]
+    assert peaks["peak_node_ram_gb"] == 2.0
+    assert peaks["net_ram_added_gb"] == 0.0  # only one valid sample survives -> min == max
+
+
+def test_skips_rows_with_non_numeric_value(tmp_path):
+    csv_path = tmp_path / "telemetry.csv"
+    json_path = tmp_path / "density.json"
+    write_csv(csv_path, [
+        ["t0", "node_memory_working_set_bytes", "not-a-number"],
+        ["t1", "node_memory_working_set_bytes", str(1 * 1024**3)],
+    ])
+    write_json(json_path, {})
+
+    process_telemetry(str(csv_path), str(json_path))
+
+    peaks = json.loads(json_path.read_text())["node_telemetry_peaks"]
+    assert peaks["peak_node_ram_gb"] == 1.0
+    assert peaks["net_ram_added_gb"] == 0.0
+
+
+def test_missing_metric_defaults_to_zero(tmp_path):
+    csv_path = tmp_path / "telemetry.csv"
+    json_path = tmp_path / "density.json"
+    write_csv(csv_path, [["t0", "unrelated_metric", "5"]])
+    write_json(json_path, {})
+
+    process_telemetry(str(csv_path), str(json_path))
+
+    peaks = json.loads(json_path.read_text())["node_telemetry_peaks"]
+    assert peaks["peak_node_ram_gb"] == 0.0
+    assert peaks["net_ram_added_gb"] == 0.0
+    assert peaks["net_swap_added_gb"] == 0.0

--- a/examples/hermes-agents-as-a-service/gateway/test_gateway.py
+++ b/examples/hermes-agents-as-a-service/gateway/test_gateway.py
@@ -1,0 +1,398 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Unit tests for the hermes-agents-as-a-service gateway example.
+
+gateway.py runs as the control+data plane in front of agent-sandbox; these
+tests cover its security/parsing logic (bearer-token auth, DNS-1123 user
+validation, the mode x conditions state machine) and the /users and
+idle-sweeper decision logic, with the Kubernetes CustomObjectsApi mocked.
+No kind cluster or container build is needed.
+
+gateway.py isn't a valid module name to import as a package member from a
+test file that also wants a fresh module per test (its top level calls
+config.load_incluster_config()/load_kube_config() and reads
+os.environ["API_SERVER_KEY"], both of which would blow up or reach a real
+cluster), so each test loads its own copy by file path via the `gw`
+fixture, mirroring examples/hpa-swp-scaling/test_create_claim.py.
+"""
+
+import hashlib
+import importlib.util
+import json
+import os
+import time
+from types import SimpleNamespace
+from unittest import mock
+
+import pytest
+from kubernetes import client as k8s_client
+from kubernetes.config import ConfigException
+
+GATEWAY_PATH = os.path.join(os.path.dirname(__file__), "gateway.py")
+
+
+class _StopLoop(Exception):
+    """Sentinel used to break idle_sweeper()'s `while True` after one pass."""
+
+
+def _load_gateway(monkeypatch, mock_crd):
+    monkeypatch.setenv("API_SERVER_KEY", "test-server-key")
+    monkeypatch.setenv("NAMESPACE", "test-ns")
+    monkeypatch.setenv("POOL", "test-pool")
+    monkeypatch.setenv("IDLE_TIMEOUT", "60")
+    monkeypatch.setenv("WAKE_TIMEOUT", "120")
+
+    with mock.patch("kubernetes.config.load_incluster_config",
+                     side_effect=ConfigException("not running in a cluster")), \
+         mock.patch("kubernetes.config.load_kube_config"), \
+         mock.patch("kubernetes.client.CustomObjectsApi", return_value=mock_crd):
+        spec = importlib.util.spec_from_file_location("hermes_gateway", GATEWAY_PATH)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def gw(monkeypatch):
+    """A freshly loaded gateway module (own last_activity/in_flight state)
+    with its Kubernetes CustomObjectsApi mocked, plus a Flask test client."""
+    mock_crd = mock.MagicMock()
+    module = _load_gateway(monkeypatch, mock_crd)
+    module.app.testing = True  # propagate unhandled exceptions instead of a bare 500
+    return SimpleNamespace(module=module, crd=mock_crd, client=module.app.test_client())
+
+
+def crd_get_side_effect(claims=None, sandboxes=None):
+    """Builds a get_namespaced_custom_object side_effect that serves
+    "sandboxclaims" from `claims` and "sandboxes" from `sandboxes` (both
+    {name: obj_or_None} maps), raising a 404 ApiException for anything
+    missing -- mirroring how get_claim()/get_sandbox() interpret 404."""
+    claims = claims or {}
+    sandboxes = sandboxes or {}
+
+    def _get(group, version, namespace, plural, name):
+        if plural == "sandboxclaims":
+            table = claims
+        elif plural == "sandboxes":
+            table = sandboxes
+        else:
+            raise AssertionError(f"unexpected plural {plural!r}")
+        obj = table.get(name)
+        if obj is None:
+            raise k8s_client.ApiException(status=404)
+        return obj
+
+    return _get
+
+
+# --- condition() ---------------------------------------------------------
+
+def test_condition_true_when_status_matches(gw):
+    obj = {"status": {"conditions": [{"type": "Ready", "status": "True"}]}}
+    assert gw.module.condition(obj, "Ready") is True
+
+
+def test_condition_false_when_status_is_false(gw):
+    obj = {"status": {"conditions": [{"type": "Ready", "status": "False"}]}}
+    assert gw.module.condition(obj, "Ready") is False
+
+
+def test_condition_false_when_type_absent(gw):
+    obj = {"status": {"conditions": [{"type": "Suspended", "status": "True"}]}}
+    assert gw.module.condition(obj, "Ready") is False
+
+
+def test_condition_false_when_no_status(gw):
+    assert gw.module.condition({}, "Ready") is False
+
+
+# --- derive_state() --------------------------------------------------------
+
+def test_derive_state_provisioning_when_sandbox_missing(gw):
+    assert gw.module.derive_state(None) == "Provisioning"
+
+
+def test_derive_state_ready(gw):
+    sandbox = {"spec": {}, "status": {"conditions": [{"type": "Ready", "status": "True"}]}}
+    assert gw.module.derive_state(sandbox) == "Ready"
+
+
+def test_derive_state_waking_when_not_yet_ready(gw):
+    sandbox = {"spec": {"operatingMode": "Running"}, "status": {"conditions": []}}
+    assert gw.module.derive_state(sandbox) == "Waking"
+
+
+def test_derive_state_suspended(gw):
+    sandbox = {"spec": {"operatingMode": "Suspended"},
+               "status": {"conditions": [{"type": "Suspended", "status": "True"}]}}
+    assert gw.module.derive_state(sandbox) == "Suspended"
+
+
+def test_derive_state_suspending_while_mode_flipped_but_not_settled(gw):
+    sandbox = {"spec": {"operatingMode": "Suspended"}, "status": {"conditions": []}}
+    assert gw.module.derive_state(sandbox) == "Suspending"
+
+
+# --- authorized() ----------------------------------------------------------
+
+def _claim_for_token(module, token):
+    return {"metadata": {"annotations": {
+        module.TOKEN_ANNOTATION: hashlib.sha256(token.encode()).hexdigest()}}}
+
+
+def test_authorized_accepts_correct_bearer_token(gw):
+    claim = _claim_for_token(gw.module, "s3cret")
+    with gw.module.app.test_request_context(headers={"Authorization": "Bearer s3cret"}):
+        assert gw.module.authorized(claim) is True
+
+
+def test_authorized_rejects_wrong_token(gw):
+    claim = _claim_for_token(gw.module, "s3cret")
+    with gw.module.app.test_request_context(headers={"Authorization": "Bearer wrong"}):
+        assert gw.module.authorized(claim) is False
+
+
+def test_authorized_rejects_missing_header(gw):
+    claim = _claim_for_token(gw.module, "s3cret")
+    with gw.module.app.test_request_context():
+        assert gw.module.authorized(claim) is False
+
+
+def test_authorized_rejects_empty_bearer_token(gw):
+    claim = _claim_for_token(gw.module, "")
+    with gw.module.app.test_request_context(headers={"Authorization": "Bearer "}):
+        # bool(token) guards against an empty token matching an empty/unset
+        # annotation hash.
+        assert gw.module.authorized(claim) is False
+
+
+# --- POST /users (create_user) ---------------------------------------------
+
+@pytest.mark.parametrize("bad_user", ["Alice", "-alice", "alice-", "", "a_b", 123, None])
+def test_create_user_rejects_invalid_dns1123_label(gw, bad_user):
+    response = gw.client.post("/users", json={"user": bad_user})
+    assert response.status_code == 400
+    gw.crd.create_namespaced_custom_object.assert_not_called()
+
+
+def test_create_user_rejects_label_over_max_len(gw):
+    too_long = "a" * (gw.module.MAX_USER_LEN + 1)
+    response = gw.client.post("/users", json={"user": too_long})
+    assert response.status_code == 400
+    gw.crd.create_namespaced_custom_object.assert_not_called()
+
+
+def test_create_user_conflict_when_claim_already_exists(gw):
+    gw.crd.get_namespaced_custom_object.side_effect = crd_get_side_effect(
+        claims={"hermes-alice": {"metadata": {"name": "hermes-alice"}}})
+
+    response = gw.client.post("/users", json={"user": "alice"})
+
+    assert response.status_code == 409
+    gw.crd.create_namespaced_custom_object.assert_not_called()
+
+
+def test_create_user_conflict_on_concurrent_signup_race(gw):
+    gw.crd.get_namespaced_custom_object.side_effect = k8s_client.ApiException(status=404)
+    gw.crd.create_namespaced_custom_object.side_effect = k8s_client.ApiException(status=409)
+
+    response = gw.client.post("/users", json={"user": "alice"})
+
+    assert response.status_code == 409
+
+
+def test_create_user_success_stores_only_token_hash(gw, monkeypatch):
+    gw.crd.get_namespaced_custom_object.side_effect = k8s_client.ApiException(status=404)
+    ready_sandbox = {
+        "metadata": {"name": "hermes-alice-sbx"},
+        "spec": {},
+        "status": {"conditions": [{"type": "Ready", "status": "True"}]},
+    }
+    # wait_ready() polls with time.sleep(1); stub it out rather than racing
+    # a real poll loop in a unit test.
+    monkeypatch.setattr(gw.module, "wait_ready", lambda user, timeout: ready_sandbox)
+
+    response = gw.client.post("/users", json={"user": "alice"})
+
+    assert response.status_code == 201
+    body = response.get_json()
+    assert body["user"] == "alice"
+    assert body["state"] == "Ready"
+    assert body["sandbox"] == "hermes-alice-sbx"
+    assert body["token"]  # shown once in the response...
+
+    gw.crd.create_namespaced_custom_object.assert_called_once()
+    claim_body = gw.crd.create_namespaced_custom_object.call_args.args[4]
+    assert claim_body["metadata"]["name"] == "hermes-alice"
+    # ...but only its SHA-256 is ever sent to the API server.
+    want_hash = hashlib.sha256(body["token"].encode()).hexdigest()
+    assert claim_body["metadata"]["annotations"][gw.module.TOKEN_ANNOTATION] == want_hash
+    assert body["token"] not in json.dumps(claim_body)
+    assert claim_body["spec"]["warmPoolRef"]["name"] == "test-pool"
+    assert claim_body["spec"]["additionalPodMetadata"]["labels"]["sandbox.users.io/hermes-user"] == "alice"
+
+
+# --- GET /users/<user> and DELETE /users/<user> -----------------------------
+
+def test_get_user_not_found(gw):
+    gw.crd.get_namespaced_custom_object.side_effect = k8s_client.ApiException(status=404)
+    response = gw.client.get("/users/alice")
+    assert response.status_code == 404
+
+
+def test_get_user_requires_valid_token(gw):
+    claim = _claim_for_token(gw.module, "s3cret")
+    gw.crd.get_namespaced_custom_object.side_effect = crd_get_side_effect(
+        claims={"hermes-alice": claim})
+
+    response = gw.client.get("/users/alice", headers={"Authorization": "Bearer wrong"})
+
+    assert response.status_code == 401
+
+
+def test_get_user_returns_state_when_authorized(gw):
+    claim = _claim_for_token(gw.module, "s3cret")
+    sandbox = {"metadata": {"name": "hermes-alice-sbx"}, "spec": {},
+               "status": {"conditions": [{"type": "Ready", "status": "True"}]}}
+    claim["status"] = {"sandbox": {"name": "hermes-alice-sbx"}}
+    gw.crd.get_namespaced_custom_object.side_effect = crd_get_side_effect(
+        claims={"hermes-alice": claim}, sandboxes={"hermes-alice-sbx": sandbox})
+
+    response = gw.client.get("/users/alice", headers={"Authorization": "Bearer s3cret"})
+
+    assert response.status_code == 200
+    assert response.get_json()["state"] == "Ready"
+
+
+def test_delete_user_not_found(gw):
+    gw.crd.get_namespaced_custom_object.side_effect = k8s_client.ApiException(status=404)
+    response = gw.client.delete("/users/alice")
+    assert response.status_code == 404
+
+
+def test_delete_user_requires_valid_token(gw):
+    claim = _claim_for_token(gw.module, "s3cret")
+    gw.crd.get_namespaced_custom_object.side_effect = crd_get_side_effect(
+        claims={"hermes-alice": claim})
+
+    response = gw.client.delete("/users/alice", headers={"Authorization": "Bearer wrong"})
+
+    assert response.status_code == 401
+    gw.crd.delete_namespaced_custom_object.assert_not_called()
+
+
+def test_delete_user_cascades_and_clears_activity(gw):
+    claim = _claim_for_token(gw.module, "s3cret")
+    gw.crd.get_namespaced_custom_object.side_effect = crd_get_side_effect(
+        claims={"hermes-alice": claim})
+    gw.module.last_activity["alice"] = time.time()
+
+    response = gw.client.delete("/users/alice", headers={"Authorization": "Bearer s3cret"})
+
+    assert response.status_code == 200
+    gw.crd.delete_namespaced_custom_object.assert_called_once()
+    assert "alice" not in gw.module.last_activity
+
+
+def test_delete_user_already_gone_is_idempotent(gw):
+    claim = _claim_for_token(gw.module, "s3cret")
+    gw.crd.get_namespaced_custom_object.side_effect = crd_get_side_effect(
+        claims={"hermes-alice": claim})
+    gw.crd.delete_namespaced_custom_object.side_effect = k8s_client.ApiException(status=404)
+
+    response = gw.client.delete("/users/alice", headers={"Authorization": "Bearer s3cret"})
+
+    assert response.status_code == 200
+
+
+def test_delete_user_unexpected_api_error_propagates(gw):
+    claim = _claim_for_token(gw.module, "s3cret")
+    gw.crd.get_namespaced_custom_object.side_effect = crd_get_side_effect(
+        claims={"hermes-alice": claim})
+    gw.crd.delete_namespaced_custom_object.side_effect = k8s_client.ApiException(status=500)
+
+    with pytest.raises(k8s_client.ApiException):
+        gw.client.delete("/users/alice", headers={"Authorization": "Bearer s3cret"})
+
+
+# --- idle_sweeper() ----------------------------------------------------------
+
+def _run_one_sweep(gw):
+    # time.sleep(15) runs before the try/except in idle_sweeper's loop body,
+    # so the first call must succeed (to let one pass execute) and only the
+    # second call breaks out.
+    with mock.patch("time.sleep", side_effect=[None, _StopLoop()]):
+        with pytest.raises(_StopLoop):
+            gw.module.idle_sweeper()
+
+
+def test_idle_sweeper_suspends_idle_ready_sandbox(gw):
+    sandbox = {"metadata": {"name": "hermes-alice-sbx"}, "spec": {},
+               "status": {"conditions": [{"type": "Ready", "status": "True"}]}}
+    claim_item = {"metadata": {"name": "hermes-alice"},
+                  "status": {"sandbox": {"name": "hermes-alice-sbx"}}}
+    gw.crd.list_namespaced_custom_object.return_value = {"items": [claim_item]}
+    gw.crd.get_namespaced_custom_object.return_value = sandbox
+    gw.module.last_activity["alice"] = time.time() - gw.module.IDLE_TIMEOUT - 10
+
+    _run_one_sweep(gw)
+
+    gw.crd.patch_namespaced_custom_object.assert_called_once()
+    args = gw.crd.patch_namespaced_custom_object.call_args.args
+    assert args[4] == "hermes-alice-sbx"
+    assert args[5] == {"spec": {"operatingMode": "Suspended"}}
+
+
+def test_idle_sweeper_skips_user_with_in_flight_request(gw):
+    sandbox = {"metadata": {"name": "hermes-alice-sbx"}, "spec": {},
+               "status": {"conditions": [{"type": "Ready", "status": "True"}]}}
+    claim_item = {"metadata": {"name": "hermes-alice"},
+                  "status": {"sandbox": {"name": "hermes-alice-sbx"}}}
+    gw.crd.list_namespaced_custom_object.return_value = {"items": [claim_item]}
+    gw.crd.get_namespaced_custom_object.return_value = sandbox
+    gw.module.last_activity["alice"] = time.time() - gw.module.IDLE_TIMEOUT - 10
+    gw.module.in_flight["alice"] = 1
+
+    _run_one_sweep(gw)
+
+    gw.crd.patch_namespaced_custom_object.assert_not_called()
+
+
+def test_idle_sweeper_skips_recently_active_user(gw):
+    sandbox = {"metadata": {"name": "hermes-alice-sbx"}, "spec": {},
+               "status": {"conditions": [{"type": "Ready", "status": "True"}]}}
+    claim_item = {"metadata": {"name": "hermes-alice"},
+                  "status": {"sandbox": {"name": "hermes-alice-sbx"}}}
+    gw.crd.list_namespaced_custom_object.return_value = {"items": [claim_item]}
+    gw.crd.get_namespaced_custom_object.return_value = sandbox
+    gw.module.last_activity["alice"] = time.time()
+
+    _run_one_sweep(gw)
+
+    gw.crd.patch_namespaced_custom_object.assert_not_called()
+
+
+def test_idle_sweeper_skips_sandbox_not_ready(gw):
+    sandbox = {"metadata": {"name": "hermes-alice-sbx"}, "spec": {}, "status": {"conditions": []}}
+    claim_item = {"metadata": {"name": "hermes-alice"},
+                  "status": {"sandbox": {"name": "hermes-alice-sbx"}}}
+    gw.crd.list_namespaced_custom_object.return_value = {"items": [claim_item]}
+    gw.crd.get_namespaced_custom_object.return_value = sandbox
+    gw.module.last_activity["alice"] = time.time() - gw.module.IDLE_TIMEOUT - 10
+
+    _run_one_sweep(gw)
+
+    gw.crd.patch_namespaced_custom_object.assert_not_called()

--- a/examples/kata-aks/agent/test_agent.py
+++ b/examples/kata-aks/agent/test_agent.py
@@ -1,0 +1,200 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Unit tests for the kata-aks per-owner agent.
+
+agent.py runs as a FastAPI server backed by an OpenAI-compatible endpoint;
+these tests cover its required-settings validation, per-owner system-prompt
+construction, and the bounded in-memory chat history, with the OpenAI client
+mocked. No kind/AKS cluster, Kata node pool, or container build is needed.
+
+agent.py raises at import time if OPENAI_BASE_URL/OPENAI_API_KEY/LLM_MODEL
+are unset, so each test loads its own copy by file path with those env vars
+controlled first, mirroring
+examples/hermes-agents-as-a-service/gateway/test_gateway.py.
+"""
+
+import importlib.util
+import os
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+AGENT_PATH = os.path.join(os.path.dirname(__file__), "agent.py")
+
+REQUIRED_ENV = {
+    "OPENAI_BASE_URL": "http://example.invalid/v1",
+    "OPENAI_API_KEY": "test-key",
+    "LLM_MODEL": "test-model",
+}
+
+
+def _load_agent(monkeypatch, env):
+    for var in ("OPENAI_BASE_URL", "OPENAI_API_KEY", "LLM_MODEL"):
+        monkeypatch.delenv(var, raising=False)
+    for key, value in env.items():
+        monkeypatch.setenv(key, value)
+
+    spec = importlib.util.spec_from_file_location("kata_aks_agent", AGENT_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def make_completion(content):
+    """Builds a MagicMock matching the shape of an OpenAI ChatCompletion."""
+    completion = MagicMock()
+    completion.choices = [MagicMock(message=MagicMock(content=content))]
+    return completion
+
+
+@pytest.fixture
+def agent(monkeypatch):
+    """A freshly loaded agent module (own _history state) with its OpenAI
+    client replaced by a MagicMock, plus a FastAPI test client."""
+    module = _load_agent(monkeypatch, REQUIRED_ENV)
+    module._client = MagicMock()
+    return SimpleNamespace(module=module, client=TestClient(module.app), openai=module._client)
+
+
+# --- required settings -------------------------------------------------------
+
+def test_raises_when_all_settings_missing(monkeypatch):
+    with pytest.raises(RuntimeError) as exc_info:
+        _load_agent(monkeypatch, {})
+    for name in ("OPENAI_BASE_URL", "OPENAI_API_KEY", "LLM_MODEL"):
+        assert name in str(exc_info.value)
+
+
+def test_raises_naming_only_the_missing_setting(monkeypatch):
+    env = dict(REQUIRED_ENV)
+    del env["LLM_MODEL"]
+
+    with pytest.raises(RuntimeError) as exc_info:
+        _load_agent(monkeypatch, env)
+
+    message = str(exc_info.value)
+    assert "LLM_MODEL" in message
+    assert "OPENAI_BASE_URL" not in message
+    assert "OPENAI_API_KEY" not in message
+
+
+def test_loads_successfully_with_all_settings(monkeypatch):
+    module = _load_agent(monkeypatch, REQUIRED_ENV)
+    assert module.app is not None
+
+
+# --- /healthz ------------------------------------------------------------
+
+def test_healthz(agent):
+    response = agent.client.get("/healthz")
+    assert response.status_code == 200
+    assert response.json() == {"ok": True}
+
+
+# --- /chat -----------------------------------------------------------------
+
+def test_chat_names_the_owner_in_the_system_prompt(agent):
+    agent.openai.chat.completions.create.return_value = make_completion("hi there")
+
+    response = agent.client.post("/chat", json={"prompt": "hello"}, headers={"X-Owner": "alice"})
+
+    assert response.status_code == 200
+    assert response.json() == {"owner": "alice", "reply": "hi there", "history_turns": 1}
+
+    messages = agent.openai.chat.completions.create.call_args.kwargs["messages"]
+    assert messages[0]["role"] == "system"
+    assert "alice's personal AI agent" in messages[0]["content"]
+    assert "I am alice's agent." in messages[0]["content"]
+    assert messages[-1] == {"role": "user", "content": "hello"}
+
+
+def test_chat_defaults_owner_to_anonymous_when_header_missing(agent):
+    agent.openai.chat.completions.create.return_value = make_completion("hi")
+
+    response = agent.client.post("/chat", json={"prompt": "hello"})
+
+    assert response.status_code == 200
+    assert response.json()["owner"] == "anonymous"
+
+
+def test_chat_includes_prior_turns_and_reports_turn_count(agent):
+    agent.openai.chat.completions.create.side_effect = [
+        make_completion("first reply"),
+        make_completion("second reply"),
+    ]
+
+    first = agent.client.post("/chat", json={"prompt": "one"}, headers={"X-Owner": "bob"})
+    assert first.json()["history_turns"] == 1
+
+    second = agent.client.post("/chat", json={"prompt": "two"}, headers={"X-Owner": "bob"})
+    assert second.json()["history_turns"] == 2
+
+    second_messages = agent.openai.chat.completions.create.call_args.kwargs["messages"]
+    assert second_messages[1] == {"role": "user", "content": "one"}
+    assert second_messages[2] == {"role": "assistant", "content": "first reply"}
+    assert second_messages[3] == {"role": "user", "content": "two"}
+
+
+def test_chat_history_is_bounded_per_owner(agent):
+    # _HISTORY_TURNS is read by the defaultdict factory the first time this
+    # owner's history is touched, so patching it here caps "alice"'s deque
+    # at 2 turns (4 messages) without needing 41 requests to prove eviction.
+    agent.module._HISTORY_TURNS = 2
+    agent.openai.chat.completions.create.side_effect = [make_completion(f"reply-{i}") for i in range(5)]
+
+    for i in range(5):
+        response = agent.client.post(
+            "/chat", json={"prompt": f"prompt-{i}"}, headers={"X-Owner": "alice"})
+        assert response.status_code == 200
+
+    history = list(agent.module._history["alice"])
+    assert len(history) == 4  # maxlen = 2 * _HISTORY_TURNS -- oldest turns evicted
+    assert history[-2] == {"role": "user", "content": "prompt-4"}
+    assert history[-1] == {"role": "assistant", "content": "reply-4"}
+
+
+def test_chat_history_is_isolated_per_owner(agent):
+    agent.openai.chat.completions.create.side_effect = [
+        make_completion("a-reply"), make_completion("b-reply")]
+
+    agent.client.post("/chat", json={"prompt": "hi"}, headers={"X-Owner": "alice"})
+    agent.client.post("/chat", json={"prompt": "hi"}, headers={"X-Owner": "bob"})
+
+    assert list(agent.module._history["alice"]) == [
+        {"role": "user", "content": "hi"}, {"role": "assistant", "content": "a-reply"}]
+    assert list(agent.module._history["bob"]) == [
+        {"role": "user", "content": "hi"}, {"role": "assistant", "content": "b-reply"}]
+
+
+# --- /reset ------------------------------------------------------------------
+
+def test_reset_clears_only_that_owners_history(agent):
+    agent.module._history["alice"].extend([{"role": "user", "content": "x"}])
+    agent.module._history["bob"].extend([{"role": "user", "content": "y"}])
+
+    response = agent.client.post("/reset", headers={"X-Owner": "alice"})
+
+    assert response.status_code == 200
+    assert response.json() == {"owner": "alice", "reset": True}
+    assert "alice" not in agent.module._history
+    assert list(agent.module._history["bob"]) == [{"role": "user", "content": "y"}]
+
+
+def test_reset_defaults_owner_to_anonymous(agent):
+    response = agent.client.post("/reset")
+    assert response.json() == {"owner": "anonymous", "reset": True}

--- a/examples/kata-aks/client/main_test.go
+++ b/examples/kata-aks/client/main_test.go
@@ -1,0 +1,186 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// uniqueOwner returns an owner name that can't collide with a concurrent
+// test run or a real cached claim. claimCachePath always resolves against
+// the real os.TempDir() (there's no injection point), so cache tests need a
+// name -- not a directory -- with the same collision-free guarantee
+// t.TempDir() gives paths.
+func uniqueOwner(t *testing.T) string {
+	t.Helper()
+	return "test-" + filepath.Base(t.TempDir())
+}
+
+func TestClaimCachePath(t *testing.T) {
+	got := claimCachePath("alice")
+	want := filepath.Join(os.TempDir(), "kata-aks-client-alice.claim")
+	if got != want {
+		t.Errorf("claimCachePath(%q) = %q, want %q", "alice", got, want)
+	}
+}
+
+func TestCachedClaimRoundTrip(t *testing.T) {
+	owner := uniqueOwner(t)
+	t.Cleanup(func() { clearCachedClaim(owner) })
+
+	if got := readCachedClaim(owner); got != "" {
+		t.Fatalf("readCachedClaim before write = %q, want empty", got)
+	}
+
+	if err := writeCachedClaim(owner, "claim-123"); err != nil {
+		t.Fatalf("writeCachedClaim: %v", err)
+	}
+	if got := readCachedClaim(owner); got != "claim-123" {
+		t.Errorf("readCachedClaim = %q, want %q", got, "claim-123")
+	}
+
+	clearCachedClaim(owner)
+	if got := readCachedClaim(owner); got != "" {
+		t.Errorf("readCachedClaim after clear = %q, want empty", got)
+	}
+}
+
+func TestWriteCachedClaimTrimsTrailingNewlineOnRead(t *testing.T) {
+	owner := uniqueOwner(t)
+	t.Cleanup(func() { clearCachedClaim(owner) })
+
+	if err := writeCachedClaim(owner, "claim-456"); err != nil {
+		t.Fatalf("writeCachedClaim: %v", err)
+	}
+	// writeCachedClaim appends its own trailing newline; readCachedClaim
+	// must strip it back off rather than returning "claim-456\n".
+	if got := readCachedClaim(owner); got != "claim-456" {
+		t.Errorf("readCachedClaim = %q, want %q (no trailing newline)", got, "claim-456")
+	}
+}
+
+func TestClearCachedClaimOnMissingFileIsNoop(t *testing.T) {
+	owner := uniqueOwner(t)
+	clearCachedClaim(owner) // must not panic or error when nothing was ever written
+}
+
+func TestChat_Success(t *testing.T) {
+	var gotReq *http.Request
+	var gotBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotReq = r
+		gotBody, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(chatResponse{
+			Owner: "alice", Reply: "I am alice's agent.", HistoryTurns: 1,
+		})
+	}))
+	defer server.Close()
+
+	resp, err := chat(context.Background(), server.URL, "sbx-1", "ns-1", "alice", "hello")
+	if err != nil {
+		t.Fatalf("chat: %v", err)
+	}
+	if resp.Owner != "alice" || resp.Reply != "I am alice's agent." || resp.HistoryTurns != 1 {
+		t.Errorf("chat() = %+v, want owner=alice reply set turns=1", resp)
+	}
+
+	if gotReq.Method != http.MethodPost || gotReq.URL.Path != "/chat" {
+		t.Errorf("request = %s %s, want POST /chat", gotReq.Method, gotReq.URL.Path)
+	}
+	wantHeaders := map[string]string{
+		"X-Sandbox-ID":        "sbx-1",
+		"X-Sandbox-Namespace": "ns-1",
+		"X-Sandbox-Port":      agentPort,
+		"X-Owner":             "alice",
+	}
+	for header, want := range wantHeaders {
+		if got := gotReq.Header.Get(header); got != want {
+			t.Errorf("header %s = %q, want %q", header, got, want)
+		}
+	}
+
+	var payload map[string]string
+	if err := json.Unmarshal(gotBody, &payload); err != nil {
+		t.Fatalf("request body is not valid JSON: %v", err)
+	}
+	if payload["prompt"] != "hello" {
+		t.Errorf("body prompt = %q, want %q", payload["prompt"], "hello")
+	}
+}
+
+func TestChat_NonSuccessStatusReturnsError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+		_, _ = w.Write([]byte("upstream unavailable"))
+	}))
+	defer server.Close()
+
+	_, err := chat(context.Background(), server.URL, "sbx-1", "ns-1", "alice", "hello")
+	if err == nil {
+		t.Fatal("chat() = nil error, want an error for a 502 response")
+	}
+	if !strings.Contains(err.Error(), "502") || !strings.Contains(err.Error(), "upstream unavailable") {
+		t.Errorf("err = %q, want it to mention status 502 and the body", err)
+	}
+}
+
+func TestChat_MalformedJSONReturnsDecodeError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("not json"))
+	}))
+	defer server.Close()
+
+	_, err := chat(context.Background(), server.URL, "sbx-1", "ns-1", "alice", "hello")
+	if err == nil {
+		t.Fatal("chat() = nil error, want a decode error")
+	}
+	if !strings.Contains(err.Error(), "decode reply") {
+		t.Errorf("err = %q, want it to mention the decode failure", err)
+	}
+}
+
+func TestChat_RequestBodyEncodesPromptRegardlessOfSpecialCharacters(t *testing.T) {
+	var gotBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotBody, _ = io.ReadAll(r.Body)
+		_ = json.NewEncoder(w).Encode(chatResponse{Owner: "alice", Reply: "ok"})
+	}))
+	defer server.Close()
+
+	prompt := `say "hi" and a newline\n`
+	if _, err := chat(context.Background(), server.URL, "sbx-1", "ns-1", "alice", prompt); err != nil {
+		t.Fatalf("chat: %v", err)
+	}
+
+	var payload map[string]string
+	if err := json.Unmarshal(gotBody, &payload); err != nil {
+		t.Fatalf("request body is not valid JSON: %v (body=%s)", err, gotBody)
+	}
+	if payload["prompt"] != prompt {
+		t.Errorf("body prompt = %q, want %q", payload["prompt"], prompt)
+	}
+}

--- a/examples/n8n-mcp/source/test_server.py
+++ b/examples/n8n-mcp/source/test_server.py
@@ -1,0 +1,151 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Unit tests for the n8n-mcp example.
+
+server.py runs inside the sandbox container as a FastAPI server whose
+/execute endpoint is the only thing standing between an n8n-triggered
+command and the shell (shlex parsing + a command allowlist). These tests
+exercise it in-process via FastAPI's TestClient, with subprocess.run
+mocked. No kind cluster or container build is needed.
+"""
+
+import subprocess
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+import server
+from server import app
+
+client = TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def working_dir(tmp_path, monkeypatch):
+    """Redirect WORKING_DIR to a scratch directory for every test.
+
+    server.WORKING_DIR is computed once at import time from
+    os.path.isdir("/app"), which would otherwise point at the real repo
+    checkout when tests run outside a container.
+    """
+    monkeypatch.setattr(server, "WORKING_DIR", str(tmp_path))
+    return tmp_path
+
+
+def test_health_check():
+    response = client.get("/")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok", "message": "Sandbox Runtime is active."}
+
+
+@patch("server.subprocess.run")
+def test_execute_allowed_command_success(mock_run, working_dir):
+    mock_run.return_value = MagicMock(stdout="hi\n", stderr="", returncode=0)
+
+    response = client.post("/execute", json={"command": "echo hi"})
+
+    assert response.status_code == 200
+    assert response.json() == {"stdout": "hi\n", "stderr": "", "exit_code": 0}
+    mock_run.assert_called_once()
+    called_args, called_kwargs = mock_run.call_args
+    assert called_args[0] == ["echo", "hi"]
+    assert called_kwargs["cwd"] == str(working_dir)
+    assert called_kwargs["timeout"] == 30
+
+
+@pytest.mark.parametrize("cmd", sorted(server.ALLOWED_COMMANDS))
+@patch("server.subprocess.run")
+def test_execute_every_allowlisted_command_is_accepted(mock_run, cmd):
+    mock_run.return_value = MagicMock(stdout="", stderr="", returncode=0)
+
+    response = client.post("/execute", json={"command": cmd})
+
+    assert response.status_code == 200
+    assert response.json()["exit_code"] == 0
+    mock_run.assert_called_once()
+
+
+@patch("server.subprocess.run")
+def test_execute_forbidden_command_is_rejected(mock_run):
+    response = client.post("/execute", json={"command": "rm -rf /"})
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["exit_code"] == 1
+    assert "Forbidden command: 'rm'" in body["stderr"]
+    mock_run.assert_not_called()
+
+
+@patch("server.subprocess.run")
+def test_execute_rejects_shell_metacharacters_via_allowlist(mock_run):
+    # shlex.split treats ";" as a literal argv token (not a shell operator),
+    # so "echo hi; rm -rf /" becomes argv=["echo", "hi;", "rm", "-rf", "/"] --
+    # a single allowlisted "echo" call with unusual-looking arguments, not a
+    # chained command. subprocess.run(args) is called with a list (shell=
+    # False), so it never invokes a shell and ";" is just an inert argument
+    # character either way. This test pins that behavior rather than the
+    # (nonexistent, since no shell is ever invoked) injection vector.
+    mock_run.return_value = MagicMock(stdout="hi;\n", stderr="", returncode=0)
+
+    response = client.post("/execute", json={"command": "echo hi; rm -rf /"})
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["exit_code"] == 0
+    mock_run.assert_called_once()
+    called_args, _ = mock_run.call_args
+    assert called_args[0] == ["echo", "hi;", "rm", "-rf", "/"]
+
+
+@patch("server.subprocess.run")
+def test_execute_malformed_syntax_is_rejected(mock_run):
+    response = client.post("/execute", json={"command": "echo 'unterminated"})
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["exit_code"] == 1
+    assert "Malformed command syntax" in body["stderr"]
+    mock_run.assert_not_called()
+
+
+@patch("server.subprocess.run")
+def test_execute_empty_command_is_rejected(mock_run):
+    response = client.post("/execute", json={"command": "   "})
+
+    assert response.status_code == 200
+    assert response.json() == {"stdout": "", "stderr": "No command provided", "exit_code": 1}
+    mock_run.assert_not_called()
+
+
+@patch("server.subprocess.run")
+def test_execute_timeout_is_reported(mock_run):
+    mock_run.side_effect = subprocess.TimeoutExpired(cmd=["ls"], timeout=30)
+
+    response = client.post("/execute", json={"command": "ls"})
+
+    assert response.status_code == 200
+    assert response.json() == {"stdout": "", "stderr": "Command timed out", "exit_code": 124}
+
+
+@patch("server.subprocess.run")
+def test_execute_unexpected_error_is_reported(mock_run):
+    mock_run.side_effect = OSError("boom")
+
+    response = client.post("/execute", json={"command": "ls"})
+
+    assert response.status_code == 200
+    assert response.json() == {"stdout": "", "stderr": "boom", "exit_code": 1}

--- a/examples/sandboxed-tools/pkg/agent/agent_test.go
+++ b/examples/sandboxed-tools/pkg/agent/agent_test.go
@@ -1,0 +1,182 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agent
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// newTestSession returns a Session backed by a scratch backup directory.
+// getBackupDir() resolves backups under os.UserHomeDir()/.local/sandboxed-tools/<name>/fs,
+// so redirecting HOME keeps these tests off the real user's home directory.
+func newTestSession(t *testing.T) *Session {
+	t.Helper()
+	t.Setenv("HOME", t.TempDir())
+	return &Session{Name: "test-session"}
+}
+
+// writeBackup creates a fake backup tarball with the given timestamp
+// component (e.g. "20260103T000000") and returns its full path.
+func writeBackup(t *testing.T, session *Session, timestamp string) string {
+	t.Helper()
+	dir, err := session.getBackupDir()
+	if err != nil {
+		t.Fatalf("getBackupDir: %v", err)
+	}
+	path := filepath.Join(dir, "backup-"+timestamp+".tar.gz")
+	if err := os.WriteFile(path, []byte("fake-tarball"), 0o600); err != nil {
+		t.Fatalf("WriteFile(%q): %v", path, err)
+	}
+	return path
+}
+
+func remainingBackups(t *testing.T, session *Session) []string {
+	t.Helper()
+	dir, err := session.getBackupDir()
+	if err != nil {
+		t.Fatalf("getBackupDir: %v", err)
+	}
+	matches, err := filepath.Glob(filepath.Join(dir, "backup-*.tar.gz"))
+	if err != nil {
+		t.Fatalf("Glob: %v", err)
+	}
+	return matches
+}
+
+func TestFindLatestBackup_NoBackups(t *testing.T) {
+	session := newTestSession(t)
+
+	got, err := session.FindLatestBackup()
+	if err != nil {
+		t.Fatalf("FindLatestBackup: %v", err)
+	}
+	if got != "" {
+		t.Errorf("FindLatestBackup() = %q, want empty string when no backups exist", got)
+	}
+}
+
+func TestFindLatestBackup_ReturnsMostRecentByTimestamp(t *testing.T) {
+	session := newTestSession(t)
+	// Written out of chronological order -- FindLatestBackup must sort by
+	// name, not by creation order or mtime.
+	writeBackup(t, session, "20260101T000000")
+	want := writeBackup(t, session, "20260103T000000")
+	writeBackup(t, session, "20260102T000000")
+
+	got, err := session.FindLatestBackup()
+	if err != nil {
+		t.Fatalf("FindLatestBackup: %v", err)
+	}
+	if got != want {
+		t.Errorf("FindLatestBackup() = %q, want %q (the newest timestamp)", got, want)
+	}
+}
+
+func TestFindLatestBackup_IgnoresNonBackupFiles(t *testing.T) {
+	session := newTestSession(t)
+	want := writeBackup(t, session, "20260101T000000")
+
+	dir, err := session.getBackupDir()
+	if err != nil {
+		t.Fatalf("getBackupDir: %v", err)
+	}
+	for _, name := range []string{"notes.txt", "backup-corrupt", "backup-20260102T000000.tar.gz.tmp"} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte("x"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	got, err := session.FindLatestBackup()
+	if err != nil {
+		t.Fatalf("FindLatestBackup: %v", err)
+	}
+	if got != want {
+		t.Errorf("FindLatestBackup() = %q, want %q (non-matching files must be ignored)", got, want)
+	}
+}
+
+func TestPruneBackups_NoBackupsIsNoop(t *testing.T) {
+	session := newTestSession(t)
+
+	if err := session.PruneBackups(t.Context(), 5); err != nil {
+		t.Fatalf("PruneBackups: %v", err)
+	}
+}
+
+func TestPruneBackups_KeepsEverythingWhenAtOrUnderKeepCount(t *testing.T) {
+	session := newTestSession(t)
+	writeBackup(t, session, "20260101T000000")
+	writeBackup(t, session, "20260102T000000")
+
+	if err := session.PruneBackups(t.Context(), 5); err != nil {
+		t.Fatalf("PruneBackups: %v", err)
+	}
+
+	if got := remainingBackups(t, session); len(got) != 2 {
+		t.Errorf("remaining backups = %v, want 2 (nothing pruned)", got)
+	}
+}
+
+func TestPruneBackups_ExactlyAtKeepCountIsNoop(t *testing.T) {
+	session := newTestSession(t)
+	writeBackup(t, session, "20260101T000000")
+	writeBackup(t, session, "20260102T000000")
+	writeBackup(t, session, "20260103T000000")
+
+	if err := session.PruneBackups(t.Context(), 3); err != nil {
+		t.Fatalf("PruneBackups: %v", err)
+	}
+
+	if got := remainingBackups(t, session); len(got) != 3 {
+		t.Errorf("remaining backups = %v, want 3 (boundary case: len == keepCount, nothing pruned)", got)
+	}
+}
+
+func TestPruneBackups_DeletesOldestKeepingNewest(t *testing.T) {
+	session := newTestSession(t)
+	writeBackup(t, session, "20260101T000000") // oldest, must be pruned
+	writeBackup(t, session, "20260102T000000") // must be pruned
+	keep1 := writeBackup(t, session, "20260103T000000")
+	keep2 := writeBackup(t, session, "20260104T000000")
+
+	if err := session.PruneBackups(t.Context(), 2); err != nil {
+		t.Fatalf("PruneBackups: %v", err)
+	}
+
+	got := remainingBackups(t, session)
+	if len(got) != 2 {
+		t.Fatalf("remaining backups = %v, want exactly 2", got)
+	}
+	remaining := map[string]bool{got[0]: true, got[1]: true}
+	if !remaining[keep1] || !remaining[keep2] {
+		t.Errorf("remaining backups = %v, want the two newest (%q, %q) -- pruning kept the wrong files", got, keep1, keep2)
+	}
+}
+
+func TestPruneBackups_ZeroKeepCountDeletesEverything(t *testing.T) {
+	session := newTestSession(t)
+	writeBackup(t, session, "20260101T000000")
+	writeBackup(t, session, "20260102T000000")
+
+	if err := session.PruneBackups(t.Context(), 0); err != nil {
+		t.Fatalf("PruneBackups: %v", err)
+	}
+
+	if got := remainingBackups(t, session); len(got) != 0 {
+		t.Errorf("remaining backups = %v, want 0", got)
+	}
+}

--- a/examples/webhook-inject-timestamp/main_test.go
+++ b/examples/webhook-inject-timestamp/main_test.go
@@ -1,0 +1,263 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	admissionv1 "k8s.io/api/admission/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// patchOp mirrors the unexported patchOperation shape in main.go. Value is
+// left as json.RawMessage since it's a string in the "existing annotations
+// map" patch but an object in the "create annotations map" patch.
+type patchOp struct {
+	Op    string          `json:"op"`
+	Path  string          `json:"path"`
+	Value json.RawMessage `json:"value,omitempty"`
+}
+
+func newAdmissionReviewBody(t *testing.T, uid types.UID, namespace, name string, object []byte) []byte {
+	t.Helper()
+	ar := admissionv1.AdmissionReview{
+		TypeMeta: metav1.TypeMeta{Kind: "AdmissionReview", APIVersion: "admission.k8s.io/v1"},
+		Request: &admissionv1.AdmissionRequest{
+			UID:       uid,
+			Namespace: namespace,
+			Name:      name,
+			Object:    runtime.RawExtension{Raw: object},
+		},
+	}
+	body, err := json.Marshal(ar)
+	if err != nil {
+		t.Fatalf("json.Marshal(AdmissionReview): %v", err)
+	}
+	return body
+}
+
+func doMutate(t *testing.T, body []byte) (*httptest.ResponseRecorder, admissionv1.AdmissionReview) {
+	t.Helper()
+	req := httptest.NewRequest("POST", "/mutate", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	handleMutate(rec, req)
+
+	var got admissionv1.AdmissionReview
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("response is not a valid AdmissionReview: %v\nbody: %s", err, rec.Body.String())
+	}
+	return rec, got
+}
+
+func TestHandleMutate_EmptyBody(t *testing.T) {
+	rec, _ := doMutateRaw(t, nil)
+	if rec.Code != 400 {
+		t.Errorf("status = %d, want 400", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), "empty body") {
+		t.Errorf("body = %q, want to contain %q", rec.Body.String(), "empty body")
+	}
+}
+
+func TestHandleMutate_MalformedJSON(t *testing.T) {
+	rec, _ := doMutateRaw(t, []byte("{not valid json"))
+	if rec.Code != 400 {
+		t.Errorf("status = %d, want 400", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), "could not decode body") {
+		t.Errorf("body = %q, want to contain %q", rec.Body.String(), "could not decode body")
+	}
+}
+
+// doMutateRaw is like doMutate but for inputs that never make it to a valid
+// AdmissionReview response (http.Error short-circuits with plain text).
+func doMutateRaw(t *testing.T, body []byte) (*httptest.ResponseRecorder, []byte) {
+	t.Helper()
+	req := httptest.NewRequest("POST", "/mutate", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	handleMutate(rec, req)
+	return rec, rec.Body.Bytes()
+}
+
+func TestHandleMutate_MissingRequest(t *testing.T) {
+	ar := admissionv1.AdmissionReview{
+		TypeMeta: metav1.TypeMeta{Kind: "AdmissionReview", APIVersion: "admission.k8s.io/v1"},
+	}
+	body, err := json.Marshal(ar)
+	if err != nil {
+		t.Fatalf("json.Marshal: %v", err)
+	}
+
+	rec, got := doMutate(t, body)
+	if rec.Code != 200 {
+		t.Fatalf("status = %d, want 200 (admission responses are always HTTP 200)", rec.Code)
+	}
+	if got.Response == nil {
+		t.Fatal("Response is nil")
+	}
+	if got.Response.Allowed {
+		t.Error("Allowed = true, want false when request is missing")
+	}
+	if got.Response.Result == nil || got.Response.Result.Message != "request is missing" {
+		t.Errorf("Result = %+v, want Message %q", got.Response.Result, "request is missing")
+	}
+}
+
+func TestHandleMutate_MissingObject(t *testing.T) {
+	body := newAdmissionReviewBody(t, "uid-1", "default", "my-claim", nil)
+
+	rec, got := doMutate(t, body)
+	if rec.Code != 200 {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if got.Response.Allowed {
+		t.Error("Allowed = true, want false when request object is missing")
+	}
+	if got.Response.Result == nil || got.Response.Result.Message != "request object is missing" {
+		t.Errorf("Result = %+v, want Message %q", got.Response.Result, "request object is missing")
+	}
+}
+
+func TestHandleMutate_UnparsableObject_FailsOpen(t *testing.T) {
+	// The object field is valid JSON but not a JSON object (a bare string),
+	// so json.Unmarshal into map[string]interface{} fails with a type
+	// error. failurePolicy: Ignore means the webhook must admit rather than
+	// reject in this case.
+	body := newAdmissionReviewBody(t, "uid-1", "default", "my-claim", []byte(`"not-an-object"`))
+
+	rec, got := doMutate(t, body)
+	if rec.Code != 200 {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if !got.Response.Allowed {
+		t.Error("Allowed = false, want true (fail open on unparsable object)")
+	}
+	if len(got.Response.Patch) != 0 {
+		t.Errorf("Patch = %s, want no patch", got.Response.Patch)
+	}
+}
+
+func TestHandleMutate_AddsAnnotationsMapWhenMissing(t *testing.T) {
+	object := `{"metadata":{"name":"my-claim"}}`
+	body := newAdmissionReviewBody(t, "uid-1", "default", "my-claim", []byte(object))
+
+	rec, got := doMutate(t, body)
+	if rec.Code != 200 {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if !got.Response.Allowed {
+		t.Error("Allowed = false, want true")
+	}
+	if got.Response.PatchType == nil || *got.Response.PatchType != admissionv1.PatchTypeJSONPatch {
+		t.Errorf("PatchType = %v, want JSONPatch", got.Response.PatchType)
+	}
+
+	var patches []patchOp
+	if err := json.Unmarshal(got.Response.Patch, &patches); err != nil {
+		t.Fatalf("patch is not valid JSON: %v (%s)", err, got.Response.Patch)
+	}
+	if len(patches) != 1 {
+		t.Fatalf("got %d patch ops, want 1: %+v", len(patches), patches)
+	}
+	p := patches[0]
+	if p.Op != "add" || p.Path != "/metadata/annotations" {
+		t.Errorf("patch op = %+v, want op=add path=/metadata/annotations", p)
+	}
+	var value map[string]string
+	if err := json.Unmarshal(p.Value, &value); err != nil {
+		t.Fatalf("patch value is not an object: %v (%s)", err, p.Value)
+	}
+	assertRecentRFC3339Nano(t, value[annotationKey])
+}
+
+func TestHandleMutate_AddsKeyToExistingAnnotationsMap(t *testing.T) {
+	object := `{"metadata":{"name":"my-claim","annotations":{"foo":"bar"}}}`
+	body := newAdmissionReviewBody(t, "uid-1", "default", "my-claim", []byte(object))
+
+	rec, got := doMutate(t, body)
+	if rec.Code != 200 {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+
+	var patches []patchOp
+	if err := json.Unmarshal(got.Response.Patch, &patches); err != nil {
+		t.Fatalf("patch is not valid JSON: %v (%s)", err, got.Response.Patch)
+	}
+	if len(patches) != 1 {
+		t.Fatalf("got %d patch ops, want 1: %+v", len(patches), patches)
+	}
+	p := patches[0]
+	wantPath := "/metadata/annotations/agents.x-k8s.io~1webhook-first-observed-at"
+	if p.Op != "add" || p.Path != wantPath {
+		t.Errorf("patch op = %+v, want op=add path=%s", p, wantPath)
+	}
+	var value string
+	if err := json.Unmarshal(p.Value, &value); err != nil {
+		t.Fatalf("patch value is not a string: %v (%s)", err, p.Value)
+	}
+	assertRecentRFC3339Nano(t, value)
+}
+
+func TestHandleMutate_NoPatchWhenAnnotationAlreadyPresent(t *testing.T) {
+	object := `{"metadata":{"name":"my-claim","annotations":{"agents.x-k8s.io/webhook-first-observed-at":"2026-01-01T00:00:00Z"}}}`
+	body := newAdmissionReviewBody(t, "uid-1", "default", "my-claim", []byte(object))
+
+	rec, got := doMutate(t, body)
+	if rec.Code != 200 {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if !got.Response.Allowed {
+		t.Error("Allowed = false, want true")
+	}
+	if len(got.Response.Patch) != 0 {
+		t.Errorf("Patch = %s, want no patch (annotation already present, should be idempotent)", got.Response.Patch)
+	}
+	if got.Response.PatchType != nil {
+		t.Errorf("PatchType = %v, want nil", got.Response.PatchType)
+	}
+}
+
+func TestHandleMutate_PreservesUIDAndTypeMeta(t *testing.T) {
+	object := `{"metadata":{"name":"my-claim"}}`
+	body := newAdmissionReviewBody(t, "abc-123-uid", "team-a", "my-claim", []byte(object))
+
+	_, got := doMutate(t, body)
+	if got.Response.UID != types.UID("abc-123-uid") {
+		t.Errorf("Response.UID = %q, want %q", got.Response.UID, "abc-123-uid")
+	}
+	if got.Kind != "AdmissionReview" || got.APIVersion != "admission.k8s.io/v1" {
+		t.Errorf("TypeMeta = %+v, want it echoed from the request", got.TypeMeta)
+	}
+}
+
+func assertRecentRFC3339Nano(t *testing.T, ts string) {
+	t.Helper()
+	parsed, err := time.Parse(time.RFC3339Nano, ts)
+	if err != nil {
+		t.Fatalf("timestamp %q is not RFC3339Nano: %v", ts, err)
+	}
+	if since := time.Since(parsed); since < 0 || since > time.Minute {
+		t.Errorf("timestamp %q is not close to now (delta %v)", ts, since)
+	}
+}


### PR DESCRIPTION
## Summary

A handful of examples under `examples/` have real logic sitting behind an HTTP endpoint with zero test coverage — allowlists and path-traversal guards standing between untrusted input and a shell or the filesystem, a mutating webhook's patch generation, small state machines that are easy to get subtly wrong. This PR adds unit tests for eight of them, following the "test what's load-bearing" guidance in `AGENTS.md` rather than chasing coverage for its own sake.

- **`n8n-mcp/source/server.py`** — the `/execute` command allowlist + `shlex` parsing that's the only thing standing between an n8n-triggered request and shell injection.
- **`webhook-inject-timestamp/main.go`** — the mutating webhook's JSON-Patch generation and JSON-Pointer escaping (easy to get subtly wrong, previously untested).
- **`hermes-agents-as-a-service/gateway/gateway.py`** — bearer-token auth, the mode × conditions state machine, DNS-1123 user validation, and the idle-sweeper's suspend decision.
- **`firecracker-sandbox/main.py`** — the workspace-escape guard (`_safe_path`) and the exec timeout / process-group-kill path.
- **`gke-swap/python-density/parse_telemetry.py`** — the CSV → JSON telemetry aggregation math.
- **`kata-aks`** — the Go client's router HTTP handling and local claim-cache I/O, plus the Python agent's required-settings validation and bounded per-owner chat history.
- **`n8n-sandbox/bridge/main.py`** — request validation and the claim-sandbox-then-always-release guarantee (verified the sandbox is released even when the command or script write fails).
- **`sandboxed-tools/pkg/agent`** — `FindLatestBackup`/`PruneBackups`, the local backup retention logic (keeps the wrong files if the sort/prune logic is ever wrong).

Each new `dev/ci/presubmits/<name>` script for the Python examples follows the same install-then-pytest shape already used by `test-analytics-tool` and `test-langchain`. The two Go suites (`webhook-inject-timestamp`, `kata-aks/client`, `sandboxed-tools/pkg/agent`) don't need a presubmit script — they're picked up automatically by the existing `go.mod`/`test-unit` discovery.

I have a companion PR against `kubernetes/test-infra` adding the Prow job entries for the six new presubmit scripts.

## Test plan

- [x] Every new suite passes locally via `python3 -m pytest` / `go test -race`
- [x] Each `dev/ci/presubmits/<name>` script verified standalone (fresh venv, matches what Prow will run)
- [x] Ran all six Python presubmit scripts end-to-end inside a real Prow-triggered pod (cloned this branch, installed deps, ran pytest) — all passed
- [x] `gofmt`, `go vet`, and scoped `golangci-lint` clean on the new Go files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive automated coverage for sandbox runtimes, FastAPI services, Kubernetes examples, client behavior, webhooks, backup management, and telemetry processing.
  * Added checks for validation, authorization, error handling, path safety, caching, request processing, and edge cases.
* **Chores**
  * Expanded the unit-test runner to support additional Python test suites and install optional test-only packages automatically.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->