### PR TITLE
WIP: test/fleet: multi-cluster benchmark for launching a million sandboxes a minute

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	go.uber.org/goleak v1.3.0
 	golang.org/x/net v0.58.0
 	golang.org/x/sync v0.22.0
+	golang.org/x/time v0.14.0
 	google.golang.org/grpc v1.83.1
 	google.golang.org/protobuf v1.36.12
 	k8s.io/api v0.36.4
@@ -88,7 +89,6 @@ require (
 	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/term v0.45.0 // indirect
 	golang.org/x/text v0.41.0 // indirect
-	golang.org/x/time v0.14.0 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.5.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260803160001-6ac0973c030d // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260803160001-6ac0973c030d // indirect

--- a/test/benchmarks/scenarios/fleet-kops-gcp/README.md
+++ b/test/benchmarks/scenarios/fleet-kops-gcp/README.md
@@ -1,0 +1,139 @@
+# Fleet launch benchmark: a million sandboxes in a minute
+
+This scenario measures how fast a *fleet* of Kubernetes clusters can launch
+Sandboxes — the [`agents.x-k8s.io`](https://github.com/kubernetes-sigs/agent-sandbox)
+`Sandbox` custom resource — and drive them to `Ready`.
+
+**Result so far:** **1,037,564 Sandboxes `Ready` inside a fixed 60-second
+window**, across **20 clusters** running **pure upstream Kubernetes** (one
+default `kube-scheduler` per cluster, no custom scheduling), with **0 create
+errors**. The verdict is computed from the server-side `Ready` condition
+timestamps, over a window fixed at `[firstReady+10s, firstReady+70s)` — it
+does not slide to find a peak, so it cannot flatter the number.
+
+## How it works
+
+One Go driver (`test/fleet`) talks to N clusters at once:
+
+- It creates Sandboxes across the fleet at a paced aggregate rate. Each
+  Sandbox's ordinal is hashed to a cluster (`fnv(id) % N`) — a deliberately
+  non-uniform, real-world-ish distribution, not a perfect round-robin.
+- Each cluster gets its **own rate limiter** at `rate / N` and its **own
+  worker pool**. A single shared limiter is unfair under wide-area latency
+  (near clusters' workers grab a disproportionate share of tokens and starve
+  far clusters), which staggers the per-cluster readiness peaks so the fleet's
+  single verdict window can't capture them together.
+- It watches **only Sandboxes** (never Pods). A pod firehose from N clusters
+  would make the driver itself the bottleneck. On a `410 Gone`
+  ("too old resource version", routine at fleet churn) the watch does a
+  reflector-style LIST resync rather than re-watching from "now", so it never
+  silently drops `Ready` transitions.
+- Artifacts are per-cluster gzipped JSONL (`creates-*.jsonl.gz`,
+  `ready-*.jsonl.gz`) plus `summary.json`. **The raw JSONL is the source of
+  truth**; the report and verdict are recomputed from it.
+
+## Prerequisites
+
+- A GCP project with billing enabled, and `gcloud` authenticated to it.
+- `go`, `python3`, and `kubectl`. `kOps` is installed automatically
+  (pinned version) into `~/.fleet-kops/bin`.
+- Per-**region** quota (these are the ones that bite at scale):
+  - `N2_CPUS` — each cluster is ~816 vCPU (`200 x n2-standard-4` workers +
+    an `n2-standard-16` controller node); a control plane adds 64–88 more.
+  - `C3_CPUS` — 88 per `c3-standard-88` control plane (see substitution note
+    below).
+  - `SSD_TOTAL_GB` — 40,960 by default. Worker boot disks are **100 GB**
+    (not the kOps default 128): two clusters sharing a region at 128 GB blow
+    the SSD quota at ~160 nodes each; 100 GB fits `2 x 200 x 100 = 40,000`.
+  - Machine **stock** is separate from quota and drifts hourly. `c3-standard-88`
+    in particular is often exhausted in a zone — probe before you commit
+    (`gcloud compute instances create ... --machine-type=c3-standard-88`,
+    then delete), and fall back to `n2-standard-64` (see below).
+
+## Run it
+
+Three scripts, each idempotent:
+
+```bash
+cd test/benchmarks/scenarios/fleet-kops-gcp
+
+# 1. Bring up the clusters (one per zone in FLEET_ZONES).
+FLEET_CLUSTER_COUNT=2 \
+FLEET_ZONES=us-east4-b,us-central1-b \
+FLEET_NODE_SIZE=n2-standard-4 \
+FLEET_CONTROL_PLANE_SIZE=c3-standard-88 \
+./up
+
+# 2. Drive the launch test and generate the HTML report.
+FLEET_COUNT=200000 FLEET_RATE=2000 ./run
+
+# 3. Tear everything down (stops billing).
+./down
+```
+
+The full 20-cluster million-sandbox run used `FLEET_COUNT=1440000`
+`FLEET_RATE=20000` (~1,000/s per cluster — the sweet spot; pushing harder
+*lowers* the result, see below) across 20 zones spread over the US, Europe,
+Asia, and Australia.
+
+Key environment knobs:
+
+| Script | Variable | Default | Notes |
+|---|---|---|---|
+| `up` | `FLEET_ZONES` | `us-east4-b,us-central1-b` | one cluster per zone; clusters are named `fleet-<zone>` |
+| `up` | `FLEET_NODE_SIZE` | `n2-standard-8` | use `n2-standard-4`: holds 512 pods/node at the same rate, half the N2 quota |
+| `up` | `FLEET_CONTROL_PLANE_SIZE` | `n2-standard-4` | use `c3-standard-88` (or `n2-standard-64`); the apiserver/etcd write path is the per-cluster ceiling |
+| `up` | `FLEET_CONTROLLER_NODE_SIZE` | `n2-standard-16` | dedicated, tainted node for the sandbox controller |
+| `up` | `FLEET_MAX_PODS` | `500` | keep below the `/23` pod-CIDR usable-IP count (~509) |
+| `up` | `FLEET_NODE_VOLUME_SIZE` | `100` | worker boot disk GB (SSD quota; see above) |
+| `run` | `FLEET_COUNT` / `FLEET_RATE` | `2000` / `200` | total Sandboxes / aggregate creates per second |
+| `run` | `FLEET_SKIP_{CLEANUP,PREPULL_CHECK,CAPACITY_CHECK}` | – | skip pre-flights (e.g. capacity check for a heterogeneous fleet) |
+| `run` | `FLEET_EXTRA_ARGS` | – | passed to the driver, e.g. `--pprof-addr=:6060` |
+
+Driver flags of note (set via `FLEET_EXTRA_ARGS`): `--create-concurrency`
+(default 512 — sized so the farthest clusters can still reach their
+per-cluster rate; a worker blocks one round trip per create, so sustaining
+`R/s` at `RTT` needs ~`R*RTT` workers) and `--conns-per-cluster` (default 8,
+must cover create-concurrency in HTTP/2 streams).
+
+## Reading the report
+
+`run` writes `report.html` into the artifacts directory and updates the
+`fleet-report-latest.html` symlink. It shows the verdict tiles (the fixed
+60s window is the headline; sliding-best is reference), aggregate created/s
+vs ready/s over time, and per-cluster small multiples. Everything is
+recomputed from the raw JSONL, and a mismatch against `summary.json` is
+rendered as a loud banner rather than silently reconciled.
+
+## What actually moves the number (hard-won)
+
+- **The verdict is readiness-bound, not driver-bound.** Once the driver isn't
+  artificially throttled, the fleet result is set by how fast the clusters
+  turn Pending pods into `Ready` ones.
+- **Each cluster tops out at ~54k `Ready`/min**, limited by its single
+  apiserver + etcd write pipeline — *not* the scheduler (which sits ~40%
+  idle). This ceiling is per-cluster and **additive**: scaling is linear
+  (measured 2.01x at 2 clusters, 5.01x at 5), so you cross 1M/min by adding
+  clusters, not by tuning one harder.
+- **Feed each cluster ~1,000/s; faster is worse.** Pushing the aggregate rate
+  up write-saturates the apiservers, and the extra create load steals capacity
+  from the readiness pipeline — creates *and* readiness both slow down.
+- **Controller tuning matters:** `--sandbox-concurrent-workers=400` plus the
+  status-write dampeners (`--sandbox-transitional-status-window`,
+  `--sandbox-write-behind-window`) on a large dedicated node lifted per-cluster
+  readiness substantially over the defaults.
+- **`n2-standard-64` is a fine control-plane substitute** when `c3-standard-88`
+  is out of stock — such clusters were top performers in the 20-cluster run.
+- **Sandbox pod template:** `automountServiceAccountToken: false` (avoids a
+  TokenRequest round trip per pod), `restartPolicy: Never`,
+  `terminationGracePeriodSeconds: 0`, and `imagePullPolicy: IfNotPresent` with
+  a pre-pulled image — so the run measures launches, not registry pulls or
+  incidental control-plane traffic.
+
+## Scaling to your own target
+
+Rough sizing: `clusters ~= ceil(target_per_min / 54000)`, one cluster per
+zone, `~1,000/s` aggregate feed per cluster. Watch the three regional quotas
+(`N2_CPUS`, `C3_CPUS`, `SSD_TOTAL_GB`) and probe `c3` stock before bring-up.
+The pre-flight in `run` (capacity check) will abort loudly rather than let a
+run discover a shortfall in the readiness curve.

--- a/test/benchmarks/scenarios/fleet-kops-gcp/down
+++ b/test/benchmarks/scenarios/fleet-kops-gcp/down
@@ -1,0 +1,51 @@
+#!/bin/bash
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# down: delete every fleet-* cluster (in parallel) and remove exported
+# kubeconfigs. Idempotent: already-deleted clusters are skipped.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+FLEET_DIR="${FLEET_DIR:-${HOME}/.fleet-kops}"
+export PATH="${FLEET_DIR}/bin:${PATH}"
+
+PROJECT_NUMBER=$(gcloud projects describe "$(gcloud config get-value project)" --format="value(projectNumber)")
+export KOPS_STATE_STORE="gs://kops-state-${PROJECT_NUMBER}"
+
+clusters=$(kops get clusters -o json 2>/dev/null | python3 -c 'import json,sys
+try:
+    for c in json.load(sys.stdin): print(c["metadata"]["name"])
+except Exception: pass' | grep "^fleet-" || true)
+
+if [[ -z "${clusters}" ]]; then
+  echo "No fleet-* clusters in ${KOPS_STATE_STORE}."
+else
+  pids=()
+  for name in ${clusters}; do
+    echo "Deleting ${name}..."
+    kops delete cluster --name "${name}" --yes > "${FLEET_DIR}/logs/down-${name}.log" 2>&1 &
+    pids+=($!)
+  done
+  fail=0
+  for pid in "${pids[@]}"; do
+    wait "${pid}" || fail=1
+  done
+  [[ $fail == 0 ]] || { echo "some deletions FAILED - see ${FLEET_DIR}/logs/down-*.log"; exit 1; }
+fi
+
+rm -f "${FLEET_DIR}"/kubeconfigs/*.kubeconfig
+echo "Fleet down."

--- a/test/benchmarks/scenarios/fleet-kops-gcp/run
+++ b/test/benchmarks/scenarios/fleet-kops-gcp/run
@@ -1,0 +1,130 @@
+#!/bin/bash
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# run: drive the fleet launch test against clusters brought up by ./up.
+# Assumes kubeconfigs in FLEET_DIR/kubeconfigs. Artifacts (per-cluster
+# jsonl + summary.json) land in FLEET_ARTIFACTS.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "${REPO_ROOT}"
+
+FLEET_DIR="${FLEET_DIR:-${HOME}/.fleet-kops}"
+FLEET_COUNT="${FLEET_COUNT:-2000}"
+FLEET_RATE="${FLEET_RATE:-200}"
+FLEET_ARTIFACTS="${FLEET_ARTIFACTS:-fleet-artifacts-$(date +%Y%m%d-%H%M%S)}"
+
+kubeconfigs=("${FLEET_DIR}"/kubeconfigs/*.kubeconfig)
+[[ -e "${kubeconfigs[0]}" ]] || { echo "no kubeconfigs in ${FLEET_DIR}/kubeconfigs - run ./up first"; exit 1; }
+echo "Fleet run: ${#kubeconfigs[@]} clusters, ${FLEET_COUNT} sandboxes at ${FLEET_RATE}/s aggregate -> ${FLEET_ARTIFACTS}"
+
+# Pre-flight 1: delete namespaces from previous runs AND WAIT. Leftover
+# sandboxes hold pod capacity: a prior run's stall left every node full
+# and the next run reported ready=0 with nothing visibly wrong. Waiting
+# matters as much as deleting - terminating pods still occupy slots.
+if [[ "${FLEET_SKIP_CLEANUP:-}" != "true" ]]; then
+  for kc in "${kubeconfigs[@]}"; do
+    (
+      KC="kubectl --kubeconfig=${kc}"
+      stale=$(${KC} get ns -o name 2>/dev/null | grep "^namespace/fleet-" | cut -d/ -f2 || true)
+      for ns in ${stale}; do
+        echo "[$(basename "${kc}" .kubeconfig)] deleting stale namespace ${ns}"
+        ${KC} delete ns "${ns}" --wait=false >/dev/null
+      done
+      # Poll rather than 'kubectl wait --for=delete': a watch established
+      # mid-deletion can miss the terminal event and hang indefinitely
+      # even after the namespace is gone.
+      for ns in ${stale}; do
+        for _ in $(seq 1 160); do  # 160 x 15s = 40m
+          ${KC} get ns "${ns}" >/dev/null 2>&1 || break
+          sleep 15
+        done
+        if ${KC} get ns "${ns}" >/dev/null 2>&1; then
+          echo "[$(basename "${kc}" .kubeconfig)] FAILED: namespace ${ns} still terminating after 40m"; exit 1
+        fi
+      done
+    ) &
+  done
+  wait
+fi
+
+# Pre-flight 2: prepull verification. Restart the image-prepull daemonset
+# and wait: every node re-proves the sandbox image is on disk (instant if
+# cached, pulls if a node was replaced since up). Rules the registry out
+# of the run entirely - Docker Hub backoffs have already turned one
+# launch into readiness waves.
+if [[ "${FLEET_SKIP_PREPULL_CHECK:-}" != "true" ]]; then
+  for kc in "${kubeconfigs[@]}"; do
+    (
+      KC="kubectl --kubeconfig=${kc}"
+      ${KC} rollout restart daemonset/image-prepull --namespace default >/dev/null
+      ${KC} rollout status daemonset/image-prepull --namespace default --timeout=15m >/dev/null || {
+        echo "[$(basename "${kc}" .kubeconfig)] FAILED: image prepull did not converge"; exit 1; }
+      echo "[$(basename "${kc}" .kubeconfig)] prepull verified on all nodes"
+    ) &
+  done
+  wait
+fi
+
+# Pre-flight 3: capacity check. Free pod slots per cluster must cover its
+# hash share. FLEET_SKIP_CAPACITY_CHECK=true for a heterogeneous fleet
+# where small clusters are meant to overflow (excess pods stay Pending).
+# hash share (~count/clusters) plus 10% imbalance margin; abort loudly
+# rather than burn a run discovering it in the ready curve.
+need_per_cluster=$(( FLEET_COUNT * 11 / 10 / ${#kubeconfigs[@]} ))
+if [[ "${FLEET_SKIP_CAPACITY_CHECK:-}" != "true" ]]; then
+for kc in "${kubeconfigs[@]}"; do
+  free=$(kubectl --kubeconfig="${kc}" get nodes -l '!node-role.kubernetes.io/control-plane,!dedicated' -o json 2>/dev/null \
+    | python3 -c '
+import json,sys
+nodes=json.load(sys.stdin)["items"]
+print(sum(int(n["status"]["allocatable"]["pods"]) for n in nodes))')
+  used=$(kubectl --kubeconfig="${kc}" get pods -A --field-selector=status.phase!=Succeeded,status.phase!=Failed --no-headers 2>/dev/null | wc -l | tr -d ' ')
+  avail=$(( free - used ))
+  echo "[$(basename "${kc}" .kubeconfig)] pod capacity: allocatable=${free} used=${used} available=${avail} need~=${need_per_cluster}"
+  if (( avail < need_per_cluster )); then
+    echo "FAILED pre-flight: $(basename "${kc}" .kubeconfig) has ${avail} free pod slots, needs ~${need_per_cluster}"
+    exit 1
+  fi
+done
+fi
+
+go run ./test/fleet \
+  --kubeconfigs="${FLEET_DIR}/kubeconfigs/*.kubeconfig" \
+  --count="${FLEET_COUNT}" \
+  --rate="${FLEET_RATE}" \
+  --output-dir="${FLEET_ARTIFACTS}" \
+  ${FLEET_EXTRA_ARGS:-}
+
+echo "Artifacts in ${FLEET_ARTIFACTS}:"
+ls -la "${FLEET_ARTIFACTS}"
+cat "${FLEET_ARTIFACTS}/summary.json"
+
+# Fleet report: one self-contained HTML page over the run's jsonl.
+if python3 -c "import venv" >/dev/null 2>&1; then
+  REPORT_VENV="${FLEET_DIR}/report-venv"
+  [[ -x "${REPORT_VENV}/bin/python3" ]] || python3 -m venv "${REPORT_VENV}"
+  "${REPORT_VENV}/bin/pip" install --quiet 'duckdb>=1,<2' 'jinja2>=3,<4' 'pytz'
+  "${REPORT_VENV}/bin/python3" test/fleet/generate-report/generate_report.py \
+    --input-dir "${FLEET_ARTIFACTS}" \
+    --output "${FLEET_ARTIFACTS}/report.html"
+  # Stable pointer to the newest run's report, so an open browser tab
+  # never silently shows a previous run.
+  ln -sf "$(cd "${FLEET_ARTIFACTS}" && pwd)/report.html" fleet-report-latest.html
+  echo "Report: ${FLEET_ARTIFACTS}/report.html (also: fleet-report-latest.html)"
+fi

--- a/test/benchmarks/scenarios/fleet-kops-gcp/up
+++ b/test/benchmarks/scenarios/fleet-kops-gcp/up
@@ -1,0 +1,283 @@
+#!/bin/bash
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# up: bring up the fleet's kOps clusters (idempotent) and export one
+# kubeconfig per cluster to FLEET_DIR. Clusters have deterministic names
+# (fleet-1..fleet-N) so re-running converges: existing clusters are
+# updated/validated rather than recreated. Bring-up runs in parallel;
+# per-cluster logs land in FLEET_DIR/logs/.
+#
+# The cluster config is the single-cluster campaign's keep-list:
+# pd-ssd volumes, nodeCIDRMaskSize=23, etcd quota 8GiB, kindnet without
+# its NetworkPolicy engine, lifted client/server rate limits, maxPods
+# 512, a dedicated node for the sandbox controller, and image prepull.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "${REPO_ROOT}"
+
+FLEET_CLUSTER_COUNT="${FLEET_CLUSTER_COUNT:-2}"
+# Comma-separated zones, assigned round-robin to clusters. Spread across
+# regions: per-family CPU quotas and machine stock are regional.
+FLEET_ZONES="${FLEET_ZONES:-us-east4-b,us-central1-b}"
+FLEET_NODE_COUNT="${FLEET_NODE_COUNT:-3}"
+FLEET_NODE_SIZE="${FLEET_NODE_SIZE:-n2-standard-8}"
+FLEET_CONTROL_PLANE_SIZE="${FLEET_CONTROL_PLANE_SIZE:-n2-standard-4}"
+# Controller node: the sandbox->pod fan-out is CPU-bound (controller CPU
+# was the single-cluster campaign's dominant limiter), so the dedicated
+# node must be large. n2-standard-4 capped a full-size cluster at ~773/s
+# vs ~1,280/s on the campaign's n2-standard-16.
+FLEET_CONTROLLER_NODE_SIZE="${FLEET_CONTROLLER_NODE_SIZE:-n2-standard-16}"
+FLEET_MAX_PODS="${FLEET_MAX_PODS:-500}"
+FLEET_DIR="${FLEET_DIR:-${HOME}/.fleet-kops}"
+FLEET_VALIDATE_WAIT="${FLEET_VALIDATE_WAIT:-20m}"
+
+mkdir -p "${FLEET_DIR}/logs" "${FLEET_DIR}/kubeconfigs"
+
+BINDIR="${FLEET_DIR}/bin"
+mkdir -p "${BINDIR}"
+if [[ ! -x "${BINDIR}/kops" ]]; then
+  echo "Installing kOps to ${BINDIR}..."
+  GOBIN="${BINDIR}" go install k8s.io/kops/cmd/kops@v1.36.0
+fi
+export PATH="${BINDIR}:${PATH}"
+
+PROJECT_ID=$(gcloud config get-value project)
+PROJECT_NUMBER=$(gcloud projects describe "${PROJECT_ID}" --format="value(projectNumber)")
+export KOPS_STATE_STORE="gs://kops-state-${PROJECT_NUMBER}"
+
+# Fresh projects (the 3-day billing accounts rotate) have no state store
+# bucket yet; create it idempotently.
+if ! gcloud storage buckets describe "${KOPS_STATE_STORE}" >/dev/null 2>&1; then
+  echo "Creating state store bucket ${KOPS_STATE_STORE}..."
+  gcloud storage buckets create "${KOPS_STATE_STORE}" --project="${PROJECT_ID}" --location=us-central1
+fi
+IMAGE_PREFIX="gcr.io/${PROJECT_ID}/agent-sandbox/"
+export IMAGE_PREFIX
+
+echo "Fleet: ${FLEET_CLUSTER_COUNT} clusters, zones [${FLEET_ZONES}], ${FLEET_NODE_COUNT} x ${FLEET_NODE_SIZE} nodes each"
+echo "State store: ${KOPS_STATE_STORE}; kubeconfigs -> ${FLEET_DIR}/kubeconfigs/"
+
+# Push the controller image once for all clusters.
+echo "Pushing agent-sandbox-controller image..."
+dev/tools/push-images --image-prefix="${IMAGE_PREFIX}" --images agent-sandbox-controller
+
+IFS=',' read -ra ZONES <<< "${FLEET_ZONES}"
+
+up_one() {
+  local i=$1
+  local zone="${ZONES[$(( (i-1) % ${#ZONES[@]} ))]}"
+  local region="${zone%-*}"
+  # Name clusters by zone (fleet-us-east4-a), not ordinal (fleet-3): the
+  # zone is the thing you actually care about when reading a per-cluster
+  # number in the report or picking a cluster to debug. Assumes one cluster
+  # per zone (FLEET_ZONES entries are distinct); the round-robin only
+  # repeats a zone if FLEET_CLUSTER_COUNT exceeds the zone list.
+  local name="fleet-${zone}"
+  local kubeconfig="${FLEET_DIR}/kubeconfigs/${name}.kubeconfig"
+
+  if ! kops get cluster "${name}" >/dev/null 2>&1; then
+    echo "[${name}] creating in ${zone}..."
+    kops create cluster \
+      --cloud=gce \
+      --gce-service-account=default \
+      --networking=kindnet \
+      --name="${name}" \
+      --zones="${zone}" \
+      --project="${PROJECT_ID}" \
+      --kubernetes-version=1.36.4 \
+      --control-plane-count=1 \
+      --control-plane-size="${FLEET_CONTROL_PLANE_SIZE}" \
+      --node-count="${FLEET_NODE_COUNT}" \
+      --node-size="${FLEET_NODE_SIZE}"
+
+    kops create -f - <<EOF
+apiVersion: kops.k8s.io/v1alpha2
+kind: InstanceGroup
+metadata:
+  labels:
+    kops.k8s.io/cluster: ${name}
+  name: sandbox-controller
+spec:
+  role: Node
+  machineType: ${FLEET_CONTROLLER_NODE_SIZE}
+  minSize: 1
+  maxSize: 1
+  zones:
+  - ${zone}
+  subnets:
+  - ${region}
+EOF
+
+    # Worker root volume: pd-ssd, sized 100GB. 100 (not the kOps default
+    # 128) is deliberate: SSD_TOTAL_GB is a per-REGION quota (40,960), and
+    # when two clusters share a region 128GB caps them at ~160 nodes each
+    # (2 x 160 x 128 ~= 40,960), which starved those clusters out of the
+    # readiness window early. 100GB fits 200 nodes/cluster even doubled-up
+    # (2 x 200 x 100 = 40,000 < 40,960); 100GB is ample for OS + prepulled
+    # image + the sleep pods' negligible ephemeral use.
+    kops edit instancegroup --name "${name}" "nodes-${zone}" \
+      --set "spec.rootVolume.type=pd-ssd" \
+      --set "spec.rootVolume.size=${FLEET_NODE_VOLUME_SIZE:-100}"
+    kops edit instancegroup --name "${name}" "control-plane-${zone}" \
+      --set "spec.rootVolume.type=pd-ssd"
+
+    # IGs created via `kops create -f` don't get the channel's default
+    # image the way `kops create cluster` IGs do; copy it from the nodes IG.
+    local node_image
+    node_image=$(kops get ig --name "${name}" "nodes-${zone}" -o json | python3 -c 'import json,sys; print(json.load(sys.stdin)["spec"]["image"])')
+    kops edit instancegroup --name "${name}" sandbox-controller \
+      --set "spec.image=${node_image}" \
+      --set "spec.rootVolume.type=pd-ssd"
+
+  else
+    echo "[${name}] already exists, converging..."
+  fi
+
+  # Spec edits apply on EVERY run (idempotent state-store writes), so a
+  # converge pass picks up config added since the cluster was created.
+  # NOTE: kubelet-level changes (maxPods) only reach EXISTING nodes after
+  # a rolling update; freshly created fleets get them at first boot.
+  # The campaign keep-list; each knob's full rationale lives in
+    # test/benchmarks/scenarios/benchmarks-kops-gcp/run.
+  kops edit cluster --name "${name}" \
+    --set 'cluster.spec.networking.kindnet.networkPolicies=false' \
+    `# nodeCIDRMaskSize=23 gives ~509 usable pod IPs/node; maxPods must` \
+    `# stay below that or a packed node strands pods on kindnet "no IPs` \
+    `# available" (found on wxg0 with maxPods=512). maxPods=500 < 509 fits.` \
+    --set "cluster.spec.kubeControllerManager.nodeCIDRMaskSize=${FLEET_NODE_CIDR_MASK_SIZE:-23}" \
+    --set 'cluster.spec.etcdClusters[0].manager.env[0].name=ETCD_QUOTA_BACKEND_BYTES' \
+    --set 'cluster.spec.etcdClusters[0].manager.env[0].value=8589934592' \
+    --set 'cluster.spec.etcdClusters[1].manager.env[0].name=ETCD_QUOTA_BACKEND_BYTES' \
+    --set 'cluster.spec.etcdClusters[1].manager.env[0].value=8589934592' \
+    --set "cluster.spec.etcdClusters[0].etcdMembers[0].volumeType=pd-ssd" \
+    --set "cluster.spec.etcdClusters[1].etcdMembers[0].volumeType=pd-ssd" \
+    --set "cluster.spec.kubelet.maxPods=${FLEET_MAX_PODS}" \
+    --set 'cluster.spec.kubelet.kubeAPIQPS=1000' \
+    --set 'cluster.spec.kubelet.eventQPS=1' \
+    --set 'cluster.spec.kubelet.eventBurst=1' \
+    --set 'cluster.spec.kubeControllerManager.kubeAPIQPS=2000' \
+    --set 'cluster.spec.kubeControllerManager.kubeAPIBurst=2000' \
+    --set 'cluster.spec.kubeScheduler.qps=1000' \
+    --set 'cluster.spec.kubeScheduler.burst=1000' \
+    --set 'cluster.spec.kubeAPIServer.maxRequestsInflight=3200' \
+    --set 'cluster.spec.kubeAPIServer.maxMutatingRequestsInflight=1600'
+
+
+  kops update cluster --name "${name}" --yes
+  kops export kubecfg "${name}" --admin=48h --kubeconfig "${kubeconfig}"
+  kops validate cluster --name "${name}" --wait "${FLEET_VALIDATE_WAIT}" --kubeconfig "${kubeconfig}"
+
+  local KC="kubectl --kubeconfig=${kubeconfig}"
+
+  # Dedicated node for the controller: label AND taint after join (kOps
+  # GCE cannot render IG labels/taints - it emits GCE-invalid label keys;
+  # see the campaign notes). The taint is what actually keeps sandbox pods
+  # and system daemons off the node; the label drives the controller's
+  # nodeSelector. The node objects may take a moment to appear, so retry.
+  for _ in $(seq 1 30); do
+    ${KC} label --overwrite node -l kops.k8s.io/instancegroup=sandbox-controller dedicated=sandbox-controller 2>/dev/null | grep -q . && break
+    sleep 10
+  done
+  ${KC} taint nodes -l kops.k8s.io/instancegroup=sandbox-controller \
+    dedicated=sandbox-controller:NoSchedule --overwrite
+
+  # Controller tuning, ported from the single-cluster scaleup scenario:
+  # 400 concurrent reconcile workers (default 100 throttled per-cluster
+  # readiness to ~989/s vs ~1,280/s) and the status-write dampeners
+  # (transitional-status-window, write-behind-window) that cut redundant
+  # status writes during the launch burst. Full rationale in
+  # scaleup-kops-gcp/run.
+  echo "[${name}] deploying agent-sandbox controller..."
+  KUBECONFIG="${kubeconfig}" dev/tools/deploy-to-kube --image-prefix="${IMAGE_PREFIX}" \
+    --controller-args="${FLEET_CONTROLLER_ARGS:---kube-api-qps=2000 --kube-api-burst=4000 --sandbox-concurrent-workers=400 --sandbox-transitional-status-window=180s --sandbox-write-behind-window=1s}"
+  # Pin the controller to the dedicated node (nodeSelector) AND tolerate
+  # its taint, or the taint we just added would repel the controller too.
+  ${KC} patch deployment agent-sandbox-controller --namespace agent-sandbox-system --patch '{
+    "spec": {"template": {"spec": {
+      "nodeSelector": {"dedicated": "sandbox-controller"},
+      "tolerations": [{"key": "dedicated", "operator": "Equal", "value": "sandbox-controller", "effect": "NoSchedule"}]
+    }}}}'
+  ${KC} rollout status deployment agent-sandbox-controller --namespace agent-sandbox-system --timeout=10m
+
+  # Serve only the beta API (see the single-cluster runner for why).
+  # Patch by VERSION NAME, not array index: the versions order is not
+  # guaranteed, and served=false on the wrong entry silently disables
+  # the API the driver uses.
+  for crd in sandboxes.agents.x-k8s.io sandboxclaims.extensions.agents.x-k8s.io sandboxtemplates.extensions.agents.x-k8s.io sandboxwarmpools.extensions.agents.x-k8s.io; do
+    ${KC} get crd "${crd}" >/dev/null 2>&1 || continue
+    local versions idx
+    versions=$(${KC} get crd "${crd}" -o jsonpath='{range .spec.versions[*]}{.name} {end}')
+    idx=0
+    for v in ${versions}; do
+      if [[ "${v}" == "v1alpha1" ]]; then
+        ${KC} patch crd "${crd}" --type=json \
+          -p "[{\"op\":\"replace\",\"path\":\"/spec/versions/${idx}/served\",\"value\":false}]"
+      else
+        ${KC} patch crd "${crd}" --type=json \
+          -p "[{\"op\":\"replace\",\"path\":\"/spec/versions/${idx}/served\",\"value\":true}]"
+      fi
+      idx=$((idx+1))
+    done
+  done
+
+  # Pre-pull the sandbox image on all workers so the run measures
+  # launches, not registry pulls.
+  ${KC} apply -f - <<'EOF'
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: image-prepull
+  namespace: default
+spec:
+  selector: { matchLabels: { app: image-prepull } }
+  template:
+    metadata: { labels: { app: image-prepull } }
+    spec:
+      initContainers:
+      - name: pull
+        image: debian:latest
+        command: ["true"]
+      containers:
+      - name: pause
+        image: registry.k8s.io/pause:3.10
+EOF
+  ${KC} rollout status daemonset/image-prepull --namespace default --timeout=10m
+  echo "[${name}] READY"
+}
+
+pids=()
+names=()
+for i in $(seq 1 "${FLEET_CLUSTER_COUNT}"); do
+  name="fleet-${ZONES[$(( (i-1) % ${#ZONES[@]} ))]}"
+  names+=("${name}")
+  up_one "${i}" > "${FLEET_DIR}/logs/up-${name}.log" 2>&1 &
+  pids+=($!)
+done
+
+fail=0
+for idx in "${!pids[@]}"; do
+  if ! wait "${pids[$idx]}"; then
+    echo "FLEET UP FAILED: ${names[$idx]} (see ${FLEET_DIR}/logs/up-${names[$idx]}.log)"
+    fail=1
+  fi
+done
+[[ $fail == 0 ]] || exit 1
+
+echo "Fleet up: ${FLEET_CLUSTER_COUNT} clusters ready."
+ls -la "${FLEET_DIR}/kubeconfigs/"

--- a/test/fleet/clusters.go
+++ b/test/fleet/clusters.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 	"net/http"
+	"time"
 
 	"k8s.io/client-go/tools/clientcmd"
 )
@@ -73,7 +74,15 @@ func connectClusters(ctx context.Context, cfg config) ([]*cluster, error) {
 		for j := 0; j < cfg.ConnsPerCluster; j++ {
 			shard := *restConfig
 			j := j
-			shard.WrapTransport = func(rt http.RoundTripper) http.RoundTripper { _ = j; return rt }
+			shard.WrapTransport = func(rt http.RoundTripper) http.RoundTripper {
+				_ = j
+				if ht, ok := rt.(*http.Transport); ok {
+					ht.MaxIdleConns = 10000
+					ht.MaxIdleConnsPerHost = 500
+					ht.IdleConnTimeout = 90 * time.Second
+				}
+				return rt
+			}
 			dc, err := dynamic.NewForConfig(&shard)
 			if err != nil {
 				return nil, fmt.Errorf("client for %s: %w", name, err)

--- a/test/fleet/clusters.go
+++ b/test/fleet/clusters.go
@@ -1,0 +1,104 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	"net/http"
+
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+var gvrSandboxes = schema.GroupVersionResource{Group: "agents.x-k8s.io", Version: "v1beta1", Resource: "sandboxes"}
+
+// cluster is one member of the fleet: a name (derived from the
+// kubeconfig filename), a set of sharded dynamic clients for mutating
+// requests, and a dedicated client for the sandbox watch.
+type cluster struct {
+	Index   int
+	Name    string
+	clients []dynamic.Interface // round-robin sharded over separate connections
+	watch   dynamic.Interface
+	rr      atomic.Uint32
+
+	created atomic.Int64
+	ready   atomic.Int64
+}
+
+func (c *cluster) client() dynamic.Interface {
+	return c.clients[int(c.rr.Add(1))%len(c.clients)]
+}
+
+func connectClusters(ctx context.Context, cfg config) ([]*cluster, error) {
+	var clusters []*cluster
+	for i, kc := range cfg.Kubeconfigs {
+		restConfig, err := clientcmd.BuildConfigFromFlags("", kc)
+		if err != nil {
+			return nil, fmt.Errorf("kubeconfig %s: %w", kc, err)
+		}
+		restConfig.QPS = -1
+		restConfig.Burst = -1
+
+		name := strings.TrimSuffix(filepath.Base(kc), filepath.Ext(kc))
+		c := &cluster{Index: i, Name: name}
+
+		// Sharded mutating clients: the apiserver caps each HTTP/2
+		// connection at ~100 concurrent streams; a create burst wider
+		// than 100*conns queues client-side and pollutes the ack
+		// latency. Distinct WrapTransport closures defeat client-go's
+		// transport cache so each client really gets its own connection.
+		for j := 0; j < cfg.ConnsPerCluster; j++ {
+			shard := *restConfig
+			j := j
+			shard.WrapTransport = func(rt http.RoundTripper) http.RoundTripper { _ = j; return rt }
+			dc, err := dynamic.NewForConfig(&shard)
+			if err != nil {
+				return nil, fmt.Errorf("client for %s: %w", name, err)
+			}
+			c.clients = append(c.clients, dc)
+		}
+		watchCfg := *restConfig
+		watchCfg.WrapTransport = func(rt http.RoundTripper) http.RoundTripper { return rt }
+		wc, err := dynamic.NewForConfig(&watchCfg)
+		if err != nil {
+			return nil, err
+		}
+		c.watch = wc
+
+		// Reachability check + namespace creation up front, so a dead
+		// cluster fails the run before any creates happen anywhere.
+		nsClient := c.clients[0].Resource(schema.GroupVersionResource{Version: "v1", Resource: "namespaces"})
+		ns := &unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": "v1", "kind": "Namespace",
+			"metadata": map[string]any{"name": cfg.Namespace},
+		}}
+		if _, err := nsClient.Create(ctx, ns, metav1.CreateOptions{}); err != nil {
+			return nil, fmt.Errorf("cluster %s: creating namespace: %w", name, err)
+		}
+		log.Printf("cluster %d (%s): connected, namespace %s created", i, name, cfg.Namespace)
+		clusters = append(clusters, c)
+	}
+	return clusters, nil
+}

--- a/test/fleet/clusters.go
+++ b/test/fleet/clusters.go
@@ -17,6 +17,7 @@ package main
 import (
 	"context"
 	"fmt"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"log"
 	"path/filepath"
 	"strings"
@@ -94,7 +95,9 @@ func connectClusters(ctx context.Context, cfg config) ([]*cluster, error) {
 			"apiVersion": "v1", "kind": "Namespace",
 			"metadata": map[string]any{"name": cfg.Namespace},
 		}}
-		if _, err := nsClient.Create(ctx, ns, metav1.CreateOptions{}); err != nil {
+		// Tolerate AlreadyExists: a create whose response was lost (WAN
+		// timeout) succeeds server-side, and the retry must not abort the run.
+		if _, err := nsClient.Create(ctx, ns, metav1.CreateOptions{}); err != nil && !apierrors.IsAlreadyExists(err) {
 			return nil, fmt.Errorf("cluster %s: creating namespace: %w", name, err)
 		}
 		log.Printf("cluster %d (%s): connected, namespace %s created", i, name, cfg.Namespace)

--- a/test/fleet/creator.go
+++ b/test/fleet/creator.go
@@ -1,0 +1,229 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"hash/fnv"
+	"log"
+	"sync"
+	"time"
+
+	"golang.org/x/time/rate"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// runCreates drives the aggregate paced create load. One global rate
+// limiter enforces the fleet-wide rate; per-cluster worker pools do the
+// creating. Each sandbox's ordinal hashes to its cluster, so a given ID
+// always lands on the same cluster (restartable, and analysis can
+// recompute the assignment offline).
+func runCreates(ctx context.Context, cfg config, clusters []*cluster, rec *recorder, start time.Time) error {
+	n := len(clusters)
+
+	// Assign every ordinal to its hashed cluster in one up-front pass,
+	// into per-cluster id lists. This keeps the (deliberately non-uniform)
+	// fnv distribution off the per-create hot path AND removes the single
+	// pacer goroutine that used to hand ids to per-cluster channels: that
+	// pacer blocked on a full channel whenever ONE cluster fell behind,
+	// starving every other cluster behind the slowest one (the ~10k/s
+	// fleet ceiling where all clusters throttled equally). Each cluster
+	// now drives its own share independently; a slow cluster only slows
+	// itself.
+	ids := make([][]int, n)
+	for id := 0; id < cfg.Count; id++ {
+		ci := clusterFor(id, n)
+		ids[ci] = append(ids[ci], id)
+	}
+
+	// Per-cluster rate limiters, each at Rate/N. A single fleet-wide shared
+	// limiter looks fair but is NOT under WAN latency: low-latency (near)
+	// clusters' workers complete a create and come back for the next token
+	// far sooner than high-latency (far) clusters' workers, so the near
+	// clusters win a disproportionate share of tokens and drain first while
+	// the far clusters are starved below their share. That staggers the
+	// per-cluster readiness peaks across time (near clusters peak early and
+	// finish, far clusters peak late), and the fleet's single 60s verdict
+	// window can't capture peaks that don't overlap - measured 104k (~10%)
+	// lost to staggering at 20 clusters. A dedicated limiter per cluster
+	// paces every cluster to exactly Rate/N regardless of distance, so the
+	// peaks align and the fleet window captures them together.
+	burst := cfg.CreatePerCluster
+	if burst < 1 {
+		burst = 1
+	}
+	perClusterRate := rate.Limit(cfg.Rate / float64(n))
+	limiters := make([]*rate.Limiter, n)
+	for i := range limiters {
+		limiters[i] = rate.NewLimiter(perClusterRate, burst)
+	}
+
+	// Progress logger.
+	logDone := make(chan struct{})
+	go func() {
+		t := time.NewTicker(5 * time.Second)
+		defer t.Stop()
+		for {
+			select {
+			case <-logDone:
+				return
+			case <-ctx.Done():
+				return
+			case <-t.C:
+				var created, ready int64
+				for _, c := range clusters {
+					created += c.created.Load()
+					ready += c.ready.Load()
+				}
+				log.Printf("[fleet +%s] created=%d ready=%d", time.Since(start).Round(time.Second), created, ready)
+			}
+		}
+	}()
+
+	var wg sync.WaitGroup
+	for ci, c := range clusters {
+		myIDs := ids[ci]
+		for w := 0; w < cfg.CreatePerCluster; w++ {
+			wg.Add(1)
+			// Pin each worker to one of the cluster's sharded clients
+			// (round-robin over connections) and to a disjoint stride of
+			// this cluster's ids - no per-create client selection, no
+			// coordination between workers.
+			res := c.clients[w%len(c.clients)].Resource(gvrSandboxes).Namespace(cfg.Namespace)
+			limiter := limiters[ci]
+			go func(c *cluster, res dynamicCreator, limiter *rate.Limiter, w int) {
+				defer wg.Done()
+				for k := w; k < len(myIDs); k += cfg.CreatePerCluster {
+					id := myIDs[k]
+					if err := limiter.Wait(ctx); err != nil {
+						return
+					}
+					obj := buildSandbox(cfg, id)
+					t0 := time.Now()
+					_, err := res.Create(ctx, obj, metav1.CreateOptions{})
+					if err != nil {
+						if ctx.Err() != nil {
+							return
+						}
+						rec.RecordCreateError(c, id, err)
+						continue
+					}
+					c.created.Add(1)
+					rec.RecordCreate(c, id, t0, time.Since(t0))
+				}
+			}(c, res, limiter, w)
+		}
+	}
+	wg.Wait()
+	close(logDone)
+
+	var created int64
+	for _, c := range clusters {
+		created += c.created.Load()
+	}
+	log.Printf("[fleet] creates done: %d/%d in %s", created, cfg.Count, time.Since(start).Round(time.Second))
+	return ctx.Err()
+}
+
+// dynamicCreator is the create-only slice of the dynamic resource client
+// each worker holds (pinned to one connection shard).
+type dynamicCreator interface {
+	Create(ctx context.Context, obj *unstructured.Unstructured, options metav1.CreateOptions, subresources ...string) (*unstructured.Unstructured, error)
+}
+
+func buildSandbox(cfg config, id int) *unstructured.Unstructured {
+	name := fmt.Sprintf("fl-%d", id)
+	spec := map[string]any{
+		"podTemplate": map[string]any{
+			"spec": map[string]any{
+				"restartPolicy": "Never",
+				// sleep(1) never handles SIGTERM, so every second of grace
+				// is pure teardown latency: 100k pods x 30s default grace
+				// blew a fleet cleanup past its timeout.
+				"terminationGracePeriodSeconds": 0,
+				// Critical for launch throughput: without this the kubelet
+				// projects a service-account token volume per pod, which
+				// means a TokenRequest call to the apiserver at every pod
+				// start - 100k extra control-plane round-trips on the exact
+				// path we are trying to keep fast. Sandboxes don't need it.
+				"automountServiceAccountToken": false,
+				// Keep sandbox pods off dedicated nodes (the pinned
+				// controller's node): kOps-on-GCE cannot render IG taints,
+				// so exclusion has to come from the workload side.
+				"affinity": map[string]any{
+					"nodeAffinity": map[string]any{
+						"requiredDuringSchedulingIgnoredDuringExecution": map[string]any{
+							"nodeSelectorTerms": []any{
+								map[string]any{
+									"matchExpressions": []any{
+										map[string]any{
+											"key":      "dedicated",
+											"operator": "DoesNotExist",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				"containers": []any{
+					map[string]any{
+						"name":  "main",
+						"image": cfg.Image,
+						// Explicit pull policy: ':latest' tags default to
+						// Always, which makes EVERY pod start a registry
+						// round-trip despite the prepull - Docker Hub
+						// backoffs turned a smoke launch into 15s waves.
+						"imagePullPolicy": "IfNotPresent",
+						"command":         []any{"sleep", "infinity"},
+						// Non-zero request so scheduler spreading and node
+						// capacity math behave like real workloads (and, on
+						// lane-partitioned clusters, so nodes cannot be
+						// stuffed past their partition share).
+						"resources": map[string]any{
+							"requests": map[string]any{"cpu": "5m"},
+						},
+					},
+				},
+			},
+		},
+	}
+	if len(cfg.SchedulerNames) > 0 {
+		lane := laneFor(name, len(cfg.SchedulerNames))
+		podSpec := spec["podTemplate"].(map[string]any)["spec"].(map[string]any)
+		if cfg.SchedulerNames[lane] != "default-scheduler" {
+			podSpec["schedulerName"] = cfg.SchedulerNames[lane]
+		}
+		if cfg.PartitionLabel != "" {
+			podSpec["nodeSelector"] = map[string]any{cfg.PartitionLabel: fmt.Sprintf("%d", lane)}
+		}
+	}
+	return &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "agents.x-k8s.io/v1beta1",
+		"kind":       "Sandbox",
+		"metadata":   map[string]any{"name": name},
+		"spec":       spec,
+	}}
+}
+
+// laneFor mirrors the single-cluster harness's lane hashing so lane
+// balance holds per cluster.
+func laneFor(name string, lanes int) int {
+	h := fnv.New32a()
+	h.Write([]byte(name))
+	return int(h.Sum32() % uint32(lanes))
+}

--- a/test/fleet/distribution_test.go
+++ b/test/fleet/distribution_test.go
@@ -1,0 +1,46 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import "testing"
+
+// The fleet verdict depends on every cluster carrying its share: at
+// 16 clusters x ~62.5k sandboxes, a 5% imbalance is ~3k extra sandboxes
+// on one cluster - enough to make it the straggler that decides the
+// 60s window. Guard the hash distribution stays within 2% of even.
+func TestClusterDistributionEven(t *testing.T) {
+	for _, n := range []int{2, 13, 16} {
+		counts := make([]int, n)
+		total := 1000000
+		for id := 0; id < total; id++ {
+			counts[clusterFor(id, n)]++
+		}
+		want := total / n
+		for i, got := range counts {
+			skew := float64(got-want) / float64(want)
+			if skew > 0.02 || skew < -0.02 {
+				t.Errorf("n=%d cluster %d: %d sandboxes, %.1f%% from even", n, i, got, skew*100)
+			}
+		}
+	}
+}
+
+func TestClusterForDeterministic(t *testing.T) {
+	for id := 0; id < 1000; id++ {
+		if clusterFor(id, 16) != clusterFor(id, 16) {
+			t.Fatalf("clusterFor not deterministic at id %d", id)
+		}
+	}
+}

--- a/test/fleet/generate-report/generate_report.py
+++ b/test/fleet/generate-report/generate_report.py
@@ -1,0 +1,148 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Generate the fleet run report: one self-contained HTML page.
+
+Reads the fleet driver's artifacts (creates-*.jsonl.gz, ready-*.jsonl.gz,
+summary.json) and renders:
+  - verdict stat tiles (best 60s server-clock window vs the 1M/min target)
+  - an aggregate created/s vs ready/s timeline
+  - per-cluster ready-rate small multiples
+  - a per-cluster table (the data view for the charts)
+
+The raw jsonl is the source of truth: the verdict here is recomputed from
+the ready rows' server-side stamps, and a mismatch against summary.json is
+rendered as a loud warning banner, not silently reconciled.
+"""
+
+import argparse
+import glob
+import json
+import os
+
+import duckdb
+import jinja2
+import markupsafe
+
+TEMPLATE = os.path.join(os.path.dirname(__file__), "template.html.j2")
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("--input-dir", required=True)
+    p.add_argument("--output", required=True)
+    args = p.parse_args()
+
+    con = duckdb.connect()
+    con.execute("SET TimeZone='UTC'")
+
+    creates_glob = os.path.join(args.input_dir, "creates-*.jsonl.gz")
+    ready_glob = os.path.join(args.input_dir, "ready-*.jsonl.gz")
+    if not glob.glob(creates_glob) or not glob.glob(ready_glob):
+        raise SystemExit(f"no fleet artifacts under {args.input_dir}")
+
+    with open(os.path.join(args.input_dir, "summary.json")) as f:
+        summary = json.load(f)
+
+    # t0 = first create (client clock, driver-wide).
+    t0 = con.execute(
+        f"SELECT min(created::TIMESTAMPTZ) FROM read_json_auto('{creates_glob}')"
+    ).fetchone()[0]
+
+    # Aggregate per-second created and ready rates. Server-side ready
+    # stamps have 1s granularity, which matches this bucketing exactly.
+    created_series = con.execute(f"""
+        SELECT date_diff('second', TIMESTAMPTZ '{t0}', created::TIMESTAMPTZ) AS t, count(*) AS n
+        FROM read_json_auto('{creates_glob}') GROUP BY t ORDER BY t""").fetchall()
+    ready_series = con.execute(f"""
+        SELECT date_diff('second', TIMESTAMPTZ '{t0}', serverReady::TIMESTAMPTZ) AS t, count(*) AS n
+        FROM read_json_auto('{ready_glob}') GROUP BY t ORDER BY t""").fetchall()
+
+    per_cluster_ready = con.execute(f"""
+        SELECT cluster, date_diff('second', TIMESTAMPTZ '{t0}', serverReady::TIMESTAMPTZ) AS t, count(*) AS n
+        FROM read_json_auto('{ready_glob}') GROUP BY cluster, t ORDER BY cluster, t""").fetchall()
+
+    cluster_stats = con.execute(f"""
+        WITH c AS (
+          SELECT cluster, count(*) AS created,
+                 round(quantile_cont(ackMs, 0.5), 1) AS ack_p50,
+                 round(quantile_cont(ackMs, 0.99), 1) AS ack_p99
+          FROM read_json_auto('{creates_glob}') GROUP BY cluster),
+        r AS (
+          SELECT cluster, count(*) AS ready,
+                 date_diff('second', TIMESTAMPTZ '{t0}', min(serverReady::TIMESTAMPTZ)) AS first_ready_s,
+                 date_diff('second', TIMESTAMPTZ '{t0}', max(serverReady::TIMESTAMPTZ)) AS last_ready_s
+          FROM read_json_auto('{ready_glob}') GROUP BY cluster)
+        SELECT c.cluster, c.created, coalesce(r.ready, 0), c.ack_p50, c.ack_p99,
+               r.first_ready_s, r.last_ready_s
+        FROM c LEFT JOIN r ON c.cluster = r.cluster ORDER BY c.cluster""").fetchall()
+
+    # Recompute both windows from raw rows (source of truth). Fixed
+    # [firstReady+10s, +70s) is the honest headline; sliding is reference.
+    best60 = con.execute(f"""
+        WITH s AS (SELECT serverReady::TIMESTAMPTZ AS ts FROM read_json_auto('{ready_glob}'))
+        SELECT max(cnt) FROM (
+          SELECT count(*) OVER (
+            ORDER BY ts RANGE BETWEEN CURRENT ROW AND INTERVAL 60 SECONDS FOLLOWING
+          ) AS cnt FROM s)""").fetchone()[0] or 0
+    fixed60 = con.execute(f"""
+        WITH s AS (SELECT serverReady::TIMESTAMPTZ AS ts FROM read_json_auto('{ready_glob}')),
+        w AS (SELECT min(ts) + INTERVAL 10 SECONDS AS lo FROM s)
+        SELECT count(*) FROM s, w WHERE ts >= w.lo AND ts < w.lo + INTERVAL 60 SECONDS""").fetchone()[0] or 0
+
+    verdict_mismatch = fixed60 != summary.get("fixedWindow60s")
+
+    def series_json(rows):
+        return [[int(t), int(n)] for t, n in rows if t is not None]
+
+    clusters = sorted({row[0] for row in per_cluster_ready})
+    per_cluster = {
+        name: series_json([(t, n) for c, t, n in per_cluster_ready if c == name])
+        for name in clusters
+    }
+
+    env = jinja2.Environment(
+        loader=jinja2.FileSystemLoader(os.path.dirname(TEMPLATE)),
+        autoescape=True,
+    )
+    def js(v):
+        # Inline-JSON for a <script> block: autoescape would HTML-escape
+        # the quotes (a JS syntax error that silently kills every chart),
+        # so these are marked safe after neutralizing '<' (script-close).
+        return markupsafe.Markup(json.dumps(v).replace("<", "\\u003c"))
+
+    html = env.get_template(os.path.basename(TEMPLATE)).render(
+        summary=summary,
+        best60=best60,
+        fixed60=fixed60,
+        verdict_mismatch=verdict_mismatch,
+        created_series=js(series_json(created_series)),
+        ready_series=js(series_json(ready_series)),
+        per_cluster=js(per_cluster),
+        cluster_stats=cluster_stats,
+        input_dir=os.path.abspath(args.input_dir),
+    )
+    # Self-check: an HTML entity inside the script block means autoescape
+    # mangled the inline JSON - a silent all-charts-dead failure mode.
+    script = html.split("<script>", 1)[1].split("</script>", 1)[0]
+    if "&#" in script or "&amp;" in script:
+        raise SystemExit("BUG: HTML-escaped content inside <script>; charts would not render")
+
+    with open(args.output, "w") as f:
+        f.write(html)
+    print(f"wrote {args.output} (best60={best60}, clusters={len(clusters)})")
+
+
+if __name__ == "__main__":
+    main()

--- a/test/fleet/generate-report/template.html.j2
+++ b/test/fleet/generate-report/template.html.j2
@@ -1,0 +1,288 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Fleet launch report</title>
+<style>
+  .viz-root {
+    color-scheme: light;
+    --surface-1: #fcfcfb;
+    --surface-2: #f1f0ee;
+    --text-primary: #0b0b0b;
+    --text-secondary: #52514e;
+    --grid: #e3e2df;
+    --series-created: #2a78d6;
+    --series-ready: #008300;
+    --good: #008300;
+    --serious: #e34948;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root:where(:not([data-theme="light"])) .viz-root {
+      color-scheme: dark;
+      --surface-1: #1a1a19;
+      --surface-2: #242423;
+      --text-primary: #ffffff;
+      --text-secondary: #c3c2b7;
+      --grid: #38383573;
+      --series-created: #3987e5;
+      --series-ready: #008300;
+      --good: #008300;
+      --serious: #e66767;
+    }
+  }
+  .viz-root {
+    font: 14px/1.45 system-ui, sans-serif;
+    background: var(--surface-1);
+    color: var(--text-primary);
+    margin: 0; padding: 24px; min-height: 100vh; box-sizing: border-box;
+  }
+  h1 { font-size: 20px; margin: 0 0 4px; }
+  .sub { color: var(--text-secondary); margin-bottom: 20px; }
+  .tiles { display: flex; gap: 12px; flex-wrap: wrap; margin-bottom: 24px; }
+  .tile {
+    background: var(--surface-2); border-radius: 8px; padding: 14px 18px; min-width: 150px;
+  }
+  .tile .v { font-size: 26px; font-weight: 650; letter-spacing: -0.02em; }
+  .tile .k { color: var(--text-secondary); font-size: 12px; margin-top: 2px; }
+  .tile.met .v { color: var(--good); }
+  .tile.notmet .v { color: var(--serious); }
+  .warn {
+    background: color-mix(in srgb, var(--serious) 12%, var(--surface-1));
+    border: 1px solid var(--serious); border-radius: 8px;
+    padding: 10px 14px; margin-bottom: 20px;
+  }
+  .chart-block { margin-bottom: 28px; }
+  .chart-title { font-weight: 600; margin-bottom: 2px; }
+  .chart-note { color: var(--text-secondary); font-size: 12px; margin-bottom: 8px; }
+  .legend { display: flex; gap: 16px; font-size: 12px; color: var(--text-secondary); margin-bottom: 6px; }
+  .legend .swatch { display: inline-block; width: 10px; height: 10px; border-radius: 3px; margin-right: 5px; vertical-align: -1px; }
+  svg text { fill: var(--text-secondary); font-size: 11px; }
+  svg .axis { stroke: var(--grid); stroke-width: 1; }
+  .facets { display: grid; grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)); gap: 16px; }
+  .facet { background: var(--surface-2); border-radius: 8px; padding: 10px 12px; }
+  .facet .t { font-size: 12px; font-weight: 600; margin-bottom: 4px; }
+  table { border-collapse: collapse; width: 100%; margin-top: 8px; }
+  th, td { text-align: right; padding: 6px 10px; border-bottom: 1px solid var(--grid); font-variant-numeric: tabular-nums; }
+  th:first-child, td:first-child { text-align: left; }
+  th { color: var(--text-secondary); font-weight: 600; font-size: 12px; }
+  .tooltip {
+    position: fixed; pointer-events: none; background: var(--surface-2);
+    border: 1px solid var(--grid); border-radius: 6px; padding: 6px 10px;
+    font-size: 12px; display: none; z-index: 10; box-shadow: 0 2px 8px rgb(0 0 0 / 0.15);
+  }
+</style>
+</head>
+<body class="viz-root">
+<h1>Fleet launch report</h1>
+<div class="sub">{{ summary.clusters }} clusters &middot; {{ "{:,}".format(summary.requested) }} requested &middot; artifacts: {{ input_dir }}</div>
+
+{% if verdict_mismatch %}
+<div class="warn"><strong>Verdict mismatch:</strong> summary.json reports fixed-60s
+{{ "{:,}".format(summary.fixedWindow60s) }}, but recomputing from the raw ready rows gives
+{{ "{:,}".format(best60) }}. The raw rows are the source of truth; investigate before citing either number.</div>
+{% endif %}
+
+<div class="tiles">
+  <div class="tile {{ 'met' if fixed60 >= summary.targetPerMinute else 'notmet' }}">
+    <div class="v">{{ "{:,}".format(fixed60) }}</div>
+    <div class="k">fixed 60s window (firstReady+10s) &middot; target {{ "{:,}".format(summary.targetPerMinute) }}</div>
+  </div>
+  <div class="tile">
+    <div class="v">{{ "{:,}".format(best60) }}</div>
+    <div class="k">sliding best 60s (reference)</div>
+  </div>
+  <div class="tile">
+    <div class="v">{{ "{:,}".format(summary.ready) }} / {{ "{:,}".format(summary.requested) }}</div>
+    <div class="k">sandboxes Ready</div>
+  </div>
+  <div class="tile {{ 'notmet' if summary.createErrors else '' }}">
+    <div class="v">{{ "{:,}".format(summary.createErrors) }}</div>
+    <div class="k">create errors</div>
+  </div>
+  <div class="tile">
+    <div class="v">{{ "%.0f"|format(summary.wallSeconds) }}s</div>
+    <div class="k">wall time</div>
+  </div>
+</div>
+
+<div class="chart-block">
+  <div class="chart-title">Sandboxes over time</div>
+  <div class="chart-note">cumulative totals across the fleet; the gap between the lines is work in flight</div>
+  <div class="legend">
+    <span><span class="swatch" style="background:var(--series-created)"></span>created</span>
+    <span><span class="swatch" style="background:var(--series-ready)"></span>ready</span>
+  </div>
+  <div id="cumchart"></div>
+</div>
+
+<div class="chart-block">
+  <div class="chart-title">Fleet rates</div>
+  <div class="chart-note">sandboxes per second, aggregate across all clusters; ready uses server-side condition stamps</div>
+  <div class="legend">
+    <span><span class="swatch" style="background:var(--series-created)"></span>created</span>
+    <span><span class="swatch" style="background:var(--series-ready)"></span>ready</span>
+  </div>
+  <div id="aggchart"></div>
+</div>
+
+<div class="chart-block">
+  <div class="chart-title">Ready rate per cluster</div>
+  <div class="chart-note">sandboxes per second per cluster (server clock)</div>
+  <div class="facets" id="facets"></div>
+</div>
+
+<div class="chart-block">
+  <div class="chart-title">Per-cluster summary</div>
+  <table>
+    <thead><tr>
+      <th>cluster</th><th>created</th><th>ready</th>
+      <th>create ack p50 (ms)</th><th>p99 (ms)</th>
+      <th>first ready (s)</th><th>last ready (s)</th>
+    </tr></thead>
+    <tbody>
+    {% for row in cluster_stats %}
+      <tr>
+        <td>{{ row[0] }}</td><td>{{ "{:,}".format(row[1]) }}</td><td>{{ "{:,}".format(row[2]) }}</td>
+        <td>{{ row[3] }}</td><td>{{ row[4] }}</td>
+        <td>{{ row[5] }}</td><td>{{ row[6] }}</td>
+      </tr>
+    {% endfor %}
+    </tbody>
+  </table>
+</div>
+
+<div class="tooltip" id="tt"></div>
+
+<script>
+const CREATED = {{ created_series }};
+const READY = {{ ready_series }};
+const PER_CLUSTER = {{ per_cluster }};
+
+const css = name => getComputedStyle(document.body).getPropertyValue(name).trim();
+
+// lineChart renders series as SVG polylines with a crosshair tooltip.
+// All series share one x (seconds since first create) and one y (rate/s).
+function lineChart(el, seriesList, width, height, showAxis, unit) {
+  unit = unit === undefined ? '/s' : unit;
+  const PAD = { l: 44, r: 10, t: 8, b: showAxis ? 22 : 8 };
+  const xs = seriesList.flatMap(s => s.data.map(d => d[0]));
+  const ys = seriesList.flatMap(s => s.data.map(d => d[1]));
+  const xMax = Math.max(1, ...xs), yMax = Math.max(1, ...ys);
+  const X = t => PAD.l + (t / xMax) * (width - PAD.l - PAD.r);
+  const Y = v => height - PAD.b - (v / yMax) * (height - PAD.t - PAD.b);
+
+  const svgNS = 'http://www.w3.org/2000/svg';
+  const svg = document.createElementNS(svgNS, 'svg');
+  svg.setAttribute('viewBox', `0 0 ${width} ${height}`);
+  svg.style.width = '100%';
+
+  // recessive grid: 3 horizontal lines + baseline
+  for (const f of [0.25, 0.5, 0.75, 1.0]) {
+    const y = Y(yMax * f);
+    const g = document.createElementNS(svgNS, 'line');
+    g.setAttribute('x1', PAD.l); g.setAttribute('x2', width - PAD.r);
+    g.setAttribute('y1', y); g.setAttribute('y2', y);
+    g.setAttribute('class', 'axis');
+    svg.appendChild(g);
+    const lbl = document.createElementNS(svgNS, 'text');
+    lbl.setAttribute('x', PAD.l - 6); lbl.setAttribute('y', y + 4);
+    lbl.setAttribute('text-anchor', 'end');
+    lbl.textContent = Math.round(yMax * f).toLocaleString();
+    svg.appendChild(lbl);
+  }
+  const base = document.createElementNS(svgNS, 'line');
+  base.setAttribute('x1', PAD.l); base.setAttribute('x2', width - PAD.r);
+  base.setAttribute('y1', Y(0)); base.setAttribute('y2', Y(0));
+  base.setAttribute('class', 'axis');
+  svg.appendChild(base);
+  if (showAxis) {
+    for (const f of [0, 0.5, 1.0]) {
+      const t = document.createElementNS(svgNS, 'text');
+      t.setAttribute('x', X(xMax * f)); t.setAttribute('y', height - 6);
+      t.setAttribute('text-anchor', f === 0 ? 'start' : f === 1 ? 'end' : 'middle');
+      t.textContent = Math.round(xMax * f) + 's';
+      svg.appendChild(t);
+    }
+  }
+
+  for (const s of seriesList) {
+    const pts = s.data.map(d => `${X(d[0]).toFixed(1)},${Y(d[1]).toFixed(1)}`).join(' ');
+    const pl = document.createElementNS(svgNS, 'polyline');
+    pl.setAttribute('points', pts);
+    pl.setAttribute('fill', 'none');
+    pl.setAttribute('stroke', s.color);
+    pl.setAttribute('stroke-width', '2');
+    pl.setAttribute('stroke-linejoin', 'round');
+    svg.appendChild(pl);
+  }
+
+  // crosshair + tooltip
+  const cross = document.createElementNS(svgNS, 'line');
+  cross.setAttribute('y1', PAD.t); cross.setAttribute('y2', height - PAD.b);
+  cross.setAttribute('stroke', css('--text-secondary'));
+  cross.setAttribute('stroke-width', '1');
+  cross.setAttribute('stroke-dasharray', '3,3');
+  cross.style.display = 'none';
+  svg.appendChild(cross);
+
+  const tt = document.getElementById('tt');
+  svg.addEventListener('mousemove', ev => {
+    const r = svg.getBoundingClientRect();
+    const px = (ev.clientX - r.left) * (width / r.width);
+    const t = Math.round(((px - PAD.l) / (width - PAD.l - PAD.r)) * xMax);
+    if (t < 0 || t > xMax) { cross.style.display = 'none'; tt.style.display = 'none'; return; }
+    cross.setAttribute('x1', X(t)); cross.setAttribute('x2', X(t));
+    cross.style.display = '';
+    const rows = seriesList.map(s => {
+      const hit = s.data.find(d => d[0] === t);
+      return `<span class="swatch" style="background:${s.color}"></span>${s.name}: ${(hit ? hit[1] : 0).toLocaleString()}${unit}`;
+    }).join('<br>');
+    tt.innerHTML = `t=+${t}s<br>${rows}`;
+    tt.style.display = 'block';
+    tt.style.left = (ev.clientX + 14) + 'px';
+    tt.style.top = (ev.clientY + 14) + 'px';
+  });
+  svg.addEventListener('mouseleave', () => { cross.style.display = 'none'; tt.style.display = 'none'; });
+
+  el.appendChild(svg);
+}
+
+// dense: fill missing seconds with explicit zeros, from t=0. Sparse
+// series make polylines interpolate ACROSS quiet periods (a stall reads
+// as a smooth ramp) and start mid-chart at the first event.
+function dense(series) {
+  if (!series.length) return [];
+  const byT = new Map(series);
+  const tMax = series[series.length - 1][0];
+  const out = [];
+  for (let t = 0; t <= tMax; t++) out.push([t, byT.get(t) || 0]);
+  return out;
+}
+
+function cumulative(series) {
+  let total = 0;
+  return dense(series).map(([t, n]) => [t, total += n]);
+}
+
+lineChart(document.getElementById('cumchart'), [
+  { name: 'created', color: css('--series-created'), data: cumulative(CREATED) },
+  { name: 'ready', color: css('--series-ready'), data: cumulative(READY) },
+], 960, 300, true, '');
+
+lineChart(document.getElementById('aggchart'), [
+  { name: 'created', color: css('--series-created'), data: dense(CREATED) },
+  { name: 'ready', color: css('--series-ready'), data: dense(READY) },
+], 960, 260, true);
+
+const facets = document.getElementById('facets');
+for (const [name, data] of Object.entries(PER_CLUSTER)) {
+  const div = document.createElement('div');
+  div.className = 'facet';
+  div.innerHTML = `<div class="t">${name}</div>`;
+  facets.appendChild(div);
+  lineChart(div, [{ name: name + ' ready', color: css('--series-ready'), data: dense(data) }], 300, 110, true);
+}
+</script>
+</body>
+</html>

--- a/test/fleet/main.go
+++ b/test/fleet/main.go
@@ -1,0 +1,163 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// fleet drives Sandbox creation across MANY clusters at an aggregate
+// target rate, to demonstrate fleet-level launch throughput (the
+// 1M-sandboxes-per-minute campaign). It is deliberately NOT the
+// single-cluster stress harness: it watches ONLY sandboxes (a pod
+// firehose from N clusters would make the driver the bottleneck - a
+// lesson the single-cluster campaign paid for twice), it holds no
+// per-pod state, and its artifacts are per-cluster jsonl files shaped
+// for duckdb plus a fleet-level server-clock verdict.
+//
+// Phase 1 operates on pre-provisioned clusters: pass one kubeconfig per
+// cluster. Sandboxes are distributed by hash of their ordinal ID, so
+// the assignment is deterministic and even without coordination.
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"hash/fnv"
+	"log"
+	"net/http"
+	_ "net/http/pprof" // driver self-profiling; the 10k/s ceiling is CPU/lock-bound, not I/O
+	"os"
+	"os/signal"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"time"
+)
+
+func main() {
+	if err := run(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+type config struct {
+	Kubeconfigs      []string
+	Count            int
+	Rate             float64
+	Namespace        string
+	Image            string
+	OutputDir        string
+	ConnsPerCluster  int
+	CreatePerCluster int // concurrent creates per cluster
+	Timeout          time.Duration
+	SchedulerNames   []string
+	PartitionLabel   string
+}
+
+func run() error {
+	var cfg config
+	var kubeconfigList string
+	flag.StringVar(&kubeconfigList, "kubeconfigs", "", "comma-separated kubeconfig paths, one per cluster (or a glob, e.g. '/tmp/fleet/*.kubeconfig')")
+	flag.IntVar(&cfg.Count, "count", 1000000, "total sandboxes to create across the fleet")
+	flag.Float64Var(&cfg.Rate, "rate", 16667, "aggregate create rate across the fleet, sandboxes/s")
+	flag.StringVar(&cfg.Namespace, "namespace", "", "namespace to create in (default fleet-<timestamp>)")
+	flag.StringVar(&cfg.Image, "image", "debian:latest", "sandbox image (pre-pull it; the fleet run should not measure registry pulls)")
+	flag.StringVar(&cfg.OutputDir, "output-dir", "", "artifact directory (default fleet-artifacts-<timestamp>)")
+	flag.IntVar(&cfg.ConnsPerCluster, "conns-per-cluster", 8, "HTTP/2 connections per cluster for mutating requests (~100 concurrent streams each; must cover create-concurrency)")
+	flag.IntVar(&cfg.CreatePerCluster, "create-concurrency", 512, "concurrent create workers per cluster. Sized for the FARTHEST clusters: a worker blocks one round trip per create, so sustaining R/s at RTT needs ~R*RTT workers. 256 workers capped a ~300ms-RTT (Mumbai/Sydney) cluster near ~500/s even when its Rate/N limiter allowed 1000/s; 512 covers a ~500ms effective RTT at 1000/s.")
+	flag.DurationVar(&cfg.Timeout, "timeout", 30*time.Minute, "overall run timeout")
+	schedulerNames := flag.String("scheduler-names", "", "comma-separated schedulerName lanes (matches the scaleup cluster config; empty = default scheduler)")
+	flag.StringVar(&cfg.PartitionLabel, "scheduler-partition-label", "", "node label key for scheduler lane partitions")
+	pprofAddr := flag.String("pprof-addr", "", "if set, serve net/http/pprof here (e.g. :6060) to profile the driver during a run")
+	flag.Parse()
+
+	if *pprofAddr != "" {
+		go func() { log.Printf("pprof: %v", http.ListenAndServe(*pprofAddr, nil)) }()
+	}
+
+	if kubeconfigList == "" {
+		return fmt.Errorf("--kubeconfigs is required")
+	}
+	if strings.ContainsAny(kubeconfigList, "*?[") {
+		matches, err := filepath.Glob(kubeconfigList)
+		if err != nil || len(matches) == 0 {
+			return fmt.Errorf("no kubeconfigs match %q", kubeconfigList)
+		}
+		cfg.Kubeconfigs = matches
+	} else {
+		cfg.Kubeconfigs = strings.Split(kubeconfigList, ",")
+	}
+	if *schedulerNames != "" {
+		cfg.SchedulerNames = strings.Split(*schedulerNames, ",")
+	}
+	runID := time.Now().UTC().Format("20060102-150405")
+	if cfg.Namespace == "" {
+		cfg.Namespace = "fleet-" + runID
+	}
+	if cfg.OutputDir == "" {
+		cfg.OutputDir = "fleet-artifacts-" + runID
+	}
+	if err := os.MkdirAll(cfg.OutputDir, 0o755); err != nil {
+		return err
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), cfg.Timeout)
+	defer cancel()
+	ctx, stop := signal.NotifyContext(ctx, syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	clusters, err := connectClusters(ctx, cfg)
+	if err != nil {
+		return err
+	}
+	log.Printf("fleet: %d clusters, %d sandboxes total at %.0f/s aggregate (%.0f/s per cluster mean)",
+		len(clusters), cfg.Count, cfg.Rate, cfg.Rate/float64(len(clusters)))
+
+	rec, err := newRecorder(cfg.OutputDir, clusters)
+	if err != nil {
+		return err
+	}
+	defer rec.Close()
+
+	for _, c := range clusters {
+		c := c
+		go c.watchSandboxes(ctx, cfg.Namespace, rec)
+	}
+
+	start := time.Now()
+	if err := runCreates(ctx, cfg, clusters, rec, start); err != nil {
+		return err
+	}
+
+	// Always write the summary, even if waitReady returns early: the
+	// verdict is the fixed 60s window over server-side Ready stamps, which
+	// is meaningful whether or not every last sandbox became Ready (a
+	// heterogeneous fleet routinely has unschedulable overflow on its
+	// smallest clusters). A summary + report that loudly show ready <
+	// requested beat aborting before any result is written.
+	werr := waitReady(ctx, cfg, clusters, rec, start)
+	if serr := rec.WriteSummary(cfg, clusters, start); serr != nil {
+		return serr
+	}
+	return werr
+}
+
+// clusterFor assigns a sandbox ordinal to a cluster: hash the ID so the
+// distribution is even and deterministic but NOT a perfect round-robin -
+// real request streams don't arrive pre-balanced across clusters, and a
+// strided id%n assignment would flatter the result by assuming they do.
+// The creator hashes every ordinal once up front into per-cluster id
+// lists (see runCreates), so this is off the per-create hot path.
+func clusterFor(id int, n int) int {
+	h := fnv.New32a()
+	fmt.Fprintf(h, "%d", id)
+	return int(h.Sum32() % uint32(n))
+}

--- a/test/fleet/recorder.go
+++ b/test/fleet/recorder.go
@@ -1,0 +1,232 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bufio"
+	"compress/gzip"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"sort"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// recorder writes duckdb-friendly artifacts:
+//   - creates-<cluster>.jsonl.gz: one row per create (id, ack latency)
+//   - ready-<cluster>.jsonl.gz:   one row per first Ready observation
+//     (client clock + the Ready condition's server-side transition time)
+//   - summary.json:               fleet verdict, per-cluster totals
+//
+// Raw jsonl is the source of truth; the verdict is recomputed offline
+// from server-side stamps (loud-failure philosophy: if summary and raw
+// rows disagree, the rows win).
+// recorder is sharded per cluster: each shard has its own mutex, writers,
+// dedup set, and ready-stamp slice. The previous single global mutex
+// serialized EVERY cluster's record path - and because the buffered gzip
+// writer runs Deflate compression on flush while the lock is held, one
+// cluster's periodic 1MB flush stalled all 18 clusters' recording on a
+// single core. Per-cluster shards make recording embarrassingly parallel;
+// the summary merges the shards' stamps once at the end.
+type recorder struct {
+	shards []*recShard
+	outDir string
+	errs   atomic.Int64
+}
+
+type recShard struct {
+	mu      sync.Mutex
+	creates *gzWriter
+	readys  *gzWriter
+	seen    map[string]struct{} // sandboxes already recorded Ready
+	readyTs []time.Time         // server-side ready stamps for this cluster
+}
+
+type gzWriter struct {
+	f  *os.File
+	gz *gzip.Writer
+	bw *bufio.Writer
+}
+
+func newGzWriter(path string) (*gzWriter, error) {
+	f, err := os.Create(path)
+	if err != nil {
+		return nil, err
+	}
+	gz := gzip.NewWriter(f)
+	return &gzWriter{f: f, gz: gz, bw: bufio.NewWriterSize(gz, 1<<20)}, nil
+}
+
+func (w *gzWriter) Close() error {
+	w.bw.Flush()
+	w.gz.Close()
+	return w.f.Close()
+}
+
+func newRecorder(outDir string, clusters []*cluster) (*recorder, error) {
+	r := &recorder{
+		shards: make([]*recShard, len(clusters)),
+		outDir: outDir,
+	}
+	for _, c := range clusters {
+		cw, err := newGzWriter(filepath.Join(outDir, fmt.Sprintf("creates-%s.jsonl.gz", c.Name)))
+		if err != nil {
+			return nil, err
+		}
+		rw, err := newGzWriter(filepath.Join(outDir, fmt.Sprintf("ready-%s.jsonl.gz", c.Name)))
+		if err != nil {
+			return nil, err
+		}
+		r.shards[c.Index] = &recShard{
+			creates: cw,
+			readys:  rw,
+			seen:    map[string]struct{}{},
+		}
+	}
+	return r, nil
+}
+
+func (r *recorder) RecordCreate(c *cluster, id int, at time.Time, ack time.Duration) {
+	row, _ := json.Marshal(map[string]any{
+		"id":      id,
+		"cluster": c.Name,
+		"created": at.UTC().Format(time.RFC3339Nano),
+		"ackMs":   float64(ack.Microseconds()) / 1000.0,
+	})
+	s := r.shards[c.Index]
+	s.mu.Lock()
+	s.creates.bw.Write(row)
+	s.creates.bw.WriteByte('\n')
+	s.mu.Unlock()
+}
+
+func (r *recorder) RecordCreateError(c *cluster, id int, err error) {
+	n := r.errs.Add(1)
+	if n <= 20 || n%1000 == 0 {
+		log.Printf("[%s] create %d failed (%d total errors): %v", c.Name, id, n, err)
+	}
+}
+
+// RecordReady records the FIRST Ready observation for a sandbox;
+// returns false for duplicates (watch replays after reconnect).
+func (r *recorder) RecordReady(c *cluster, name string, observed time.Time, serverReady time.Time) bool {
+	s := r.shards[c.Index]
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, dup := s.seen[name]; dup {
+		return false
+	}
+	s.seen[name] = struct{}{}
+	s.readyTs = append(s.readyTs, serverReady)
+	row, _ := json.Marshal(map[string]any{
+		"name":        name,
+		"cluster":     c.Name,
+		"observed":    observed.UTC().Format(time.RFC3339Nano),
+		"serverReady": serverReady.UTC().Format(time.RFC3339),
+	})
+	s.readys.bw.Write(row)
+	s.readys.bw.WriteByte('\n')
+	return true
+}
+
+func (r *recorder) ReadyTotal() int {
+	total := 0
+	for _, s := range r.shards {
+		s.mu.Lock()
+		total += len(s.readyTs)
+		s.mu.Unlock()
+	}
+	return total
+}
+
+func (r *recorder) Close() {
+	for _, s := range r.shards {
+		s.mu.Lock()
+		s.creates.Close()
+		s.readys.Close()
+		s.mu.Unlock()
+	}
+}
+
+// WriteSummary computes the fleet verdict from server-side Ready stamps:
+// the best 60s window across the whole fleet, plus per-cluster totals.
+func (r *recorder) WriteSummary(cfg config, clusters []*cluster, start time.Time) error {
+	var stamps []time.Time
+	for _, s := range r.shards {
+		s.mu.Lock()
+		stamps = append(stamps, s.readyTs...)
+		s.mu.Unlock()
+	}
+	errs := int(r.errs.Load())
+
+	sort.Slice(stamps, func(i, j int) bool { return stamps[i].Before(stamps[j]) })
+
+	// Two windows, both over server-side Ready stamps (one fleet-wide
+	// window, never per-cluster maxima summed):
+	//   - fixedWindow60s: a FIXED 60s window starting 10s after the first
+	//     Ready, skipping the ramp. This is the HONEST headline - it does
+	//     not slide to find a peak, so it cannot flatter the number.
+	//   - bestServer60s: the sliding max over all 60s windows. Reported for
+	//     reference; it runs a few % higher than the fixed window (61,025
+	//     vs 58,640 on a single n2-standard-4 cluster), and that gap is
+	//     enough to flip a MET/NOT-MET call at fleet scale, which is why
+	//     the verdict uses the fixed window.
+	best60 := 0
+	for i := range stamps {
+		j := sort.Search(len(stamps), func(k int) bool {
+			return stamps[k].After(stamps[i].Add(60 * time.Second))
+		})
+		if j-i > best60 {
+			best60 = j - i
+		}
+	}
+
+	fixed60 := 0
+	if len(stamps) > 0 {
+		winStart := stamps[0].Add(10 * time.Second)
+		winEnd := winStart.Add(60 * time.Second)
+		lo := sort.Search(len(stamps), func(k int) bool { return !stamps[k].Before(winStart) })
+		hi := sort.Search(len(stamps), func(k int) bool { return !stamps[k].Before(winEnd) })
+		fixed60 = hi - lo
+	}
+
+	perCluster := map[string]any{}
+	for _, c := range clusters {
+		perCluster[c.Name] = map[string]int64{
+			"created": c.created.Load(),
+			"ready":   c.ready.Load(),
+		}
+	}
+	summary := map[string]any{
+		"clusters":        len(clusters),
+		"requested":       cfg.Count,
+		"ready":           len(stamps),
+		"createErrors":    errs,
+		"aggregateRate":   cfg.Rate,
+		"fixedWindow60s":  fixed60, // headline: fixed [firstReady+10s, +70s)
+		"bestServer60s":   best60,  // reference: sliding max
+		"targetPerMinute": 1000000,
+		"met":             fixed60 >= 1000000,
+		"wallSeconds":     time.Since(start).Seconds(),
+	}
+	out, _ := json.MarshalIndent(summary, "", "  ")
+	log.Printf("FLEET RESULT: ready=%d fixed-60s-window(server clock)=%d (sliding-best=%d) met=%v",
+		len(stamps), fixed60, best60, fixed60 >= 1000000)
+	return os.WriteFile(filepath.Join(r.outDir, "summary.json"), append(out, '\n'), 0o644)
+}

--- a/test/fleet/waitready.go
+++ b/test/fleet/waitready.go
@@ -1,0 +1,60 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+)
+
+// waitReady blocks until every created sandbox has been observed Ready,
+// or no NEW sandbox has become Ready for stallTimeout (loud failure with
+// the shortfall rather than hanging forever).
+const stallTimeout = 10 * time.Minute
+
+func waitReady(ctx context.Context, cfg config, clusters []*cluster, rec *recorder, start time.Time) error {
+	var createdTotal int64
+	for _, c := range clusters {
+		createdTotal += c.created.Load()
+	}
+	last, lastProgress := -1, time.Now()
+	for {
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("timed out waiting for Ready: %d/%d", rec.ReadyTotal(), createdTotal)
+		case <-time.After(2 * time.Second):
+		}
+		n := rec.ReadyTotal()
+		if int64(n) >= createdTotal {
+			log.Printf("[fleet] all %d sandboxes Ready in %s", n, time.Since(start).Round(time.Second))
+			return nil
+		}
+		if n != last {
+			last, lastProgress = n, time.Now()
+		} else if time.Since(lastProgress) > stallTimeout {
+			// Not a fatal error: on a heterogeneous fleet the smallest
+			// clusters' overflow is genuinely unschedulable, so readiness
+			// plateaus below createdTotal by design. Log loudly and let the
+			// caller write the summary - the fixed-window verdict stands on
+			// the sandboxes that DID become Ready.
+			log.Printf("[fleet] readiness plateaued at %d/%d (%d short) - no new Ready for %s; "+
+				"remaining are unschedulable (capacity). Recording results; verdict is the fixed 60s window.",
+				n, createdTotal, int(createdTotal)-n, stallTimeout)
+			return nil
+		}
+	}
+}

--- a/test/fleet/watcher.go
+++ b/test/fleet/watcher.go
@@ -1,0 +1,155 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"log"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/dynamic"
+)
+
+// watchSandboxes follows the cluster's sandbox stream and records the
+// first Ready observation per sandbox: the client wall-clock time plus
+// the Ready condition's lastTransitionTime (the controller's clock, 1s
+// granularity) - the fleet verdict is computed from the server stamps
+// so driver lag and cross-region skew cannot inflate the result.
+//
+// Reconnects resume from the last seen resourceVersion and are ALWAYS
+// logged: a silently re-watching client hid a serious problem from the
+// single-cluster campaign for days.
+func (c *cluster) watchSandboxes(ctx context.Context, namespace string, rec *recorder) {
+	iface := c.watch.Resource(gvrSandboxes).Namespace(namespace)
+	reconnects := 0
+	// resourceVersion to resume from; "" means "position unknown, must
+	// resync". A watch started at "" resumes from the CURRENT state and
+	// sees only FUTURE events - so on a 410 (the apiserver watch cache
+	// evicting our position, which happens routinely at fleet churn) we
+	// must LIST, not just re-watch, or we silently drop every Ready
+	// transition that happened in the gap. A single fleet run lost ~370k
+	// readies this way and reported a 40% low verdict.
+	resourceVersion := ""
+	for ctx.Err() == nil {
+		if resourceVersion == "" {
+			rv, err := c.relistReady(ctx, iface, rec)
+			if err != nil {
+				if ctx.Err() == nil {
+					log.Printf("[%s] sandbox relist error, retrying: %v", c.Name, err)
+					time.Sleep(time.Second)
+				}
+				continue
+			}
+			resourceVersion = rv
+		}
+		w, err := iface.Watch(ctx, metav1.ListOptions{Watch: true, ResourceVersion: resourceVersion, AllowWatchBookmarks: true})
+		if err != nil {
+			if apiStatus, ok := err.(apierrors.APIStatus); ok && apiStatus.Status().Code == 410 {
+				resourceVersion = "" // force a resync LIST, not a from-now watch
+			}
+			if ctx.Err() == nil {
+				log.Printf("[%s] sandbox watch error, retrying: %v", c.Name, err)
+				time.Sleep(time.Second)
+			}
+			continue
+		}
+	inner:
+		for {
+			select {
+			case <-ctx.Done():
+				w.Stop()
+				return
+			case ev, ok := <-w.ResultChan():
+				if !ok {
+					reconnects++
+					log.Printf("[%s] sandbox watch closed by server, re-watching from rv=%q (reconnect #%d)", c.Name, resourceVersion, reconnects)
+					break inner
+				}
+				if ev.Type == watch.Error {
+					// 410/Expired: our resume point is gone. Force a resync
+					// LIST (resourceVersion="") so we re-derive the current
+					// Ready set instead of watching from now and losing the
+					// transitions that occurred during the gap.
+					log.Printf("[%s] sandbox watch error event, resyncing via LIST: %v", c.Name, ev.Object)
+					resourceVersion = ""
+					w.Stop()
+					break inner
+				}
+				u, ok := ev.Object.(*unstructured.Unstructured)
+				if !ok {
+					continue
+				}
+				resourceVersion = u.GetResourceVersion()
+				if ev.Type == watch.Bookmark {
+					continue
+				}
+				if ready, ltt := sandboxReady(u); ready {
+					if rec.RecordReady(c, u.GetName(), time.Now(), ltt) {
+						c.ready.Add(1)
+					}
+				}
+			}
+		}
+	}
+}
+
+// relistReady does the reflector's ListAndWatch resync: LIST all
+// sandboxes, record any already Ready (the recorder dedups by name, so
+// re-recording across resyncs is harmless and the server-side
+// lastTransitionTime keeps the verdict honest), and return the list's
+// resourceVersion to start watching from. Only a fresh LIST guarantees we
+// don't lose Ready transitions the watch cache dropped on a 410.
+func (c *cluster) relistReady(ctx context.Context, iface dynamic.ResourceInterface, rec *recorder) (string, error) {
+	list, err := iface.List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return "", err
+	}
+	for i := range list.Items {
+		u := &list.Items[i]
+		if ready, ltt := sandboxReady(u); ready {
+			if rec.RecordReady(c, u.GetName(), time.Now(), ltt) {
+				c.ready.Add(1)
+			}
+		}
+	}
+	return list.GetResourceVersion(), nil
+}
+
+// sandboxReady reports whether the Ready condition is True, returning
+// its lastTransitionTime.
+func sandboxReady(u *unstructured.Unstructured) (bool, time.Time) {
+	conditions, found, err := unstructured.NestedSlice(u.Object, "status", "conditions")
+	if err != nil || !found {
+		return false, time.Time{}
+	}
+	for _, cv := range conditions {
+		cond, ok := cv.(map[string]any)
+		if !ok {
+			continue
+		}
+		if cond["type"] == "Ready" && cond["status"] == "True" {
+			var ltt time.Time
+			if s, ok := cond["lastTransitionTime"].(string); ok {
+				ltt, _ = time.Parse(time.RFC3339, s)
+			}
+			return true, ltt
+		}
+	}
+	return false, time.Time{}
+}


### PR DESCRIPTION
One Go driver drives Sandbox creation across N pre-provisioned clusters at a
paced aggregate rate and measures how fast the fleet drives them to Ready,
over a fixed 60-second server-clock window.

Result: 1,037,564 Sandboxes Ready in the fixed window across 20 clusters on
pure upstream Kubernetes (one default kube-scheduler per cluster), 0 create
errors.

Driver (test/fleet):
- Per-cluster rate limiters and worker pools. A single shared limiter is
  unfair under wide-area latency - near clusters' workers win a
  disproportionate token share and starve far clusters, staggering the
  per-cluster readiness peaks so the fleet's single verdict window cannot
  capture them together.
- Sandbox-only watch (a pod firehose from N clusters would make the driver
  the bottleneck) with a reflector-style LIST resync on 410 Gone, so
  readiness transitions are never silently dropped.
- Verdict from server-side Ready timestamps over a FIXED [firstReady+10s,
  +70s) window, not a sliding max; raw per-cluster JSONL is the source of
  truth and a self-contained HTML report is recomputed from it.

kOps-on-GCE scenario (test/benchmarks/scenarios/fleet-kops-gcp):
- Idempotent up/run/down scripts. 100GB pd-ssd worker disks to fit the
  per-region SSD quota, maxPods=500 under the /23 pod CIDR, a tuned sandbox
  controller on a dedicated tainted node, image prepull, clusters named by
  zone.
- run pre-flights (stale-namespace drain, prepull verify, capacity check)
  and auto-generates the report.
- README covers prerequisites, the up/run/down flow, reading the report, and
  what actually moves the number (readiness-bound; ~54k/min per-cluster
  apiserver ceiling; linear scaling; feed ~1000/s per cluster).

Promotes golang.org/x/time to a direct dependency (the driver's rate
limiters).
