### PR TITLE
perf(sandbox): one status write per launch behind --sandbox-transitional-status-window

### DIFF
--- a/cmd/agent-sandbox-controller/main.go
+++ b/cmd/agent-sandbox-controller/main.go
@@ -78,6 +78,7 @@ func main() {
 	var sandboxWriteBehindWindow time.Duration
 	var sandboxWarmPoolReadinessGracePeriod time.Duration
 	var sandboxWarmPoolUnschedulableRecheckInterval time.Duration
+	var sandboxTransitionalStatusWindow time.Duration
 	var enableWarmPoolEviction bool
 	var cacheLabelSelectors bool
 	var printVersion bool
@@ -156,6 +157,12 @@ func main() {
 			"by the previous process. Default false (annotations persisted).")
 	flag.DurationVar(&sandboxWriteBehindWindow, "sandbox-write-behind-window", 0,
 		"Coalescing window for the Sandbox controller's recoverable metadata-only writes. 0 disables coalescing.")
+	flag.DurationVar(&sandboxTransitionalStatusWindow, "sandbox-transitional-status-window", 0,
+		"Defer transitional Sandbox status writes (reason/message churn and field fills while no condition changes value) "+
+			"for sandboxes younger than this window: a launch that reaches Ready inside the window writes status exactly once, "+
+			"at the Ready flip, and a sandbox that is stuck still flushes an explanatory status once the window elapses. "+
+			"Material changes (condition value flips, terminal reasons like Expired/PodFailed) are always written immediately. "+
+			"0 disables deferral (every status change is written synchronously).")
 	opts := zap.Options{
 		Development: false,
 	}
@@ -208,6 +215,11 @@ func main() {
 	if sandboxWriteBehindWindow < 0 {
 		setupLog.Error(nil, "sandbox-write-behind-window must be >= 0 (0 disables write-behind coalescing)",
 			"value", sandboxWriteBehindWindow)
+		os.Exit(1)
+	}
+	if sandboxTransitionalStatusWindow < 0 {
+		setupLog.Error(nil, "sandbox-transitional-status-window must be >= 0 (0 disables transitional-status deferral)",
+			"value", sandboxTransitionalStatusWindow)
 		os.Exit(1)
 	}
 	// A logical maximum (too much will create unnecessary load on the API server)
@@ -375,14 +387,19 @@ func main() {
 		setupLog.Info("Sandbox controller write deferral enabled (--sandbox-write-behind-window)",
 			"window", sandboxWriteBehindWindow, "podPatchBound", "1s")
 	}
+	if sandboxTransitionalStatusWindow > 0 {
+		setupLog.Info("Sandbox controller transitional-status deferral enabled (--sandbox-transitional-status-window)",
+			"window", sandboxTransitionalStatusWindow)
+	}
 
 	if err = (&controllers.SandboxReconciler{
-		Client:            mgr.GetClient(),
-		Scheme:            mgr.GetScheme(),
-		Recorder:          mgr.GetEventRecorder("sandbox-controller"),
-		Tracer:            instrumenter,
-		ClusterDomain:     clusterDomain,
-		WriteBehindWindow: sandboxWriteBehindWindow,
+		Client:                   mgr.GetClient(),
+		Scheme:                   mgr.GetScheme(),
+		Recorder:                 mgr.GetEventRecorder("sandbox-controller"),
+		Tracer:                   instrumenter,
+		ClusterDomain:            clusterDomain,
+		WriteBehindWindow:        sandboxWriteBehindWindow,
+		TransitionalStatusWindow: sandboxTransitionalStatusWindow,
 	}).SetupWithManager(mgr, sandboxConcurrentWorkers); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Sandbox")
 		os.Exit(1)

--- a/controllers/sandbox_controller.go
+++ b/controllers/sandbox_controller.go
@@ -255,6 +255,22 @@ type SandboxReconciler struct {
 	// for why this one piece of in-memory state is unavoidable and why
 	// losing it is harmless.
 	deferralClock deferredWriteClock
+
+	// TransitionalStatusWindow, when > 0, defers TRANSITIONAL status writes
+	// (see materialStatusChange) for sandboxes younger than the window: the
+	// launch fast path then writes status once, at the Ready flip, while a
+	// sandbox that is stuck still flushes an explanatory status at age
+	// == window via RequeueAfter. Material changes (Ready flips, Suspended,
+	// Finished, terminal reasons) are always written immediately. 0 (the
+	// default) preserves the fully synchronous behavior. Gated by the
+	// --sandbox-transitional-status-window flag; anchored to
+	// metadata.creationTimestamp, so no in-memory clock is needed.
+	TransitionalStatusWindow time.Duration
+
+	// staleWrites suppresses reconcile passes that observe an informer copy
+	// older than this controller's own last write to the sandbox -- the
+	// source of no-op re-PATCHes under launch load; see staleCacheGuard.
+	staleWrites staleCacheGuard
 }
 
 //+kubebuilder:rbac:groups=agents.x-k8s.io,resources=sandboxes,verbs=get;list;watch;create;update;patch;delete
@@ -284,9 +300,19 @@ func (r *SandboxReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		if k8serrors.IsNotFound(err) {
 			logger.Info("sandbox resource not found. Ignoring since object must be deleted")
 			r.deferralClock.clear(req.NamespacedName)
+			r.staleWrites.clear(req.NamespacedName)
 			return ctrl.Result{}, nil
 		}
 		return ctrl.Result{}, err
+	}
+
+	// The informer has not yet replayed this controller's own last write to
+	// this sandbox: every decision this pass could make would be re-derived
+	// from superseded state and every write it could issue would be a no-op
+	// the apiserver still has to serve. Skip the pass; the recorded write
+	// guarantees a watch event (hence a fresh reconcile) is on its way.
+	if r.staleWrites.stillStale(req.NamespacedName, sandbox.ResourceVersion) {
+		return ctrl.Result{}, nil
 	}
 
 	// Start Tracing Span
@@ -304,6 +330,7 @@ func (r *SandboxReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	if !sandbox.DeletionTimestamp.IsZero() {
 		logger.Info("Sandbox is being deleted")
 		r.deferralClock.clear(req.NamespacedName)
+		r.staleWrites.clear(req.NamespacedName)
 		return ctrl.Result{}, nil
 	}
 
@@ -316,9 +343,11 @@ func (r *SandboxReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		}
 		sandbox.Annotations[asmetrics.TraceContextAnnotation] = tc
 
+		rvBefore := sandbox.ResourceVersion
 		if err := r.Patch(ctx, sandbox, patch); err != nil {
 			return ctrl.Result{}, err
 		}
+		r.staleWrites.record(req.NamespacedName, rvBefore, sandbox.ResourceVersion)
 	}
 
 	oldStatus := sandbox.Status.DeepCopy()
@@ -330,7 +359,9 @@ func (r *SandboxReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	if expired {
 		if !sandboxMarkedExpired(sandbox) {
 			setSandboxExpiredCondition(sandbox)
-			if statusUpdateErr := r.updateStatus(ctx, oldStatus, sandbox); statusUpdateErr != nil {
+			// The Expired mark is material (terminal reason), so it is never
+			// deferred; the returned wait is always zero here.
+			if _, statusUpdateErr := r.updateStatus(ctx, oldStatus, sandbox); statusUpdateErr != nil {
 				return ctrl.Result{}, statusUpdateErr
 			}
 			return ctrl.Result{RequeueAfter: immediateRequeueDelay}, nil
@@ -376,10 +407,17 @@ func (r *SandboxReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	}
 
 	if !sandboxDeleted {
-		// Update status
-		if statusUpdateErr := r.updateStatus(ctx, oldStatus, sandbox); statusUpdateErr != nil {
+		// Update status. A deferred transitional write (non-zero wait)
+		// requeues the request so a stuck sandbox still flushes its status
+		// once the transitional window elapses; the requeue dedups with any
+		// pending write-behind requeue via the workqueue.
+		statusWait, statusUpdateErr := r.updateStatus(ctx, oldStatus, sandbox)
+		if statusUpdateErr != nil {
 			// Surface update error
 			err = errors.Join(err, statusUpdateErr)
+		}
+		if statusWait > 0 && (result.RequeueAfter == 0 || statusWait < result.RequeueAfter) {
+			result.RequeueAfter = statusWait
 		}
 	}
 	// return errors seen
@@ -719,11 +757,17 @@ func podIPsFromStatus(podIPs []corev1.PodIP) []string {
 	return ips
 }
 
-func (r *SandboxReconciler) updateStatus(ctx context.Context, oldStatus *sandboxv1beta1.SandboxStatus, sandbox *sandboxv1beta1.Sandbox) error {
+// updateStatus persists sandbox.Status if it differs from oldStatus. The
+// returned duration is non-zero when a transitional change was deferred
+// under --sandbox-transitional-status-window: the caller must requeue the
+// request after that long so a stuck sandbox still flushes its status at
+// age == window (a sandbox that progresses sooner flushes earlier, riding
+// the material write its progress produces).
+func (r *SandboxReconciler) updateStatus(ctx context.Context, oldStatus *sandboxv1beta1.SandboxStatus, sandbox *sandboxv1beta1.Sandbox) (time.Duration, error) {
 	logger := log.FromContext(ctx)
 
 	if apiequality.Semantic.DeepEqual(oldStatus, &sandbox.Status) {
-		return nil
+		return 0, nil
 	}
 
 	// Pod scheduling produces a status change containing nothing but the
@@ -737,7 +781,22 @@ func (r *SandboxReconciler) updateStatus(ctx context.Context, oldStatus *sandbox
 	// rather than leave a Ready sandbox with a wrong or missing node name.
 	if nodeNameOnlyChange(oldStatus, &sandbox.Status) &&
 		!meta.IsStatusConditionTrue(sandbox.Status.Conditions, string(sandboxv1beta1.SandboxConditionReady)) {
-		return nil
+		return 0, nil
+	}
+
+	// Transitional-status gating (--sandbox-transitional-status-window):
+	// on the launch fast path nothing reads the pre-Ready status fills, so
+	// while the sandbox is younger than the window, only material changes
+	// (Ready flips, Suspended, Finished, terminal reasons; see
+	// materialStatusChange) are written immediately. The generalization of
+	// the nodeName-only deferral above: the skipped write is recomputed from
+	// informer state whenever it eventually flushes, so nothing is lost on
+	// crash or failover. A zero creationTimestamp (never set by a real
+	// apiserver) yields a huge age and thus no deferral.
+	if r.TransitionalStatusWindow > 0 && !materialStatusChange(oldStatus, &sandbox.Status) {
+		if age := time.Since(sandbox.CreationTimestamp.Time); age < r.TransitionalStatusWindow {
+			return r.TransitionalStatusWindow - age, nil
+		}
 	}
 
 	// Merge-patch (no resourceVersion precondition) the status subresource.
@@ -753,17 +812,19 @@ func (r *SandboxReconciler) updateStatus(ctx context.Context, oldStatus *sandbox
 	//      pod state, so it self-heals on the next watch event and converges.
 	base := sandbox.DeepCopy()
 	base.Status = *oldStatus
+	rvBefore := sandbox.ResourceVersion
 	if err := r.Status().Patch(ctx, sandbox, client.MergeFrom(base)); err != nil {
 		if k8serrors.IsNotFound(err) {
 			// Sandbox was deleted mid-reconcile
-			return nil
+			return 0, nil
 		}
 		logger.Error(err, "Failed to patch sandbox status")
-		return err
+		return 0, err
 	}
+	r.staleWrites.record(client.ObjectKeyFromObject(sandbox), rvBefore, sandbox.ResourceVersion)
 
 	// Surface error
-	return nil
+	return 0, nil
 }
 
 // nodeNameOnlyChange reports whether the node assignment is the only
@@ -1156,9 +1217,11 @@ func (r *SandboxReconciler) clearPodNameAnnotation(ctx context.Context, sandbox 
 	logger := log.FromContext(ctx)
 	patch := client.MergeFrom(sandbox.DeepCopy())
 	delete(sandbox.Annotations, sandboxv1beta1.SandboxPodNameAnnotation)
+	rvBefore := sandbox.ResourceVersion
 	if err := r.Patch(ctx, sandbox, patch); err != nil {
 		return fmt.Errorf("failed to clear pod name annotation: %w", err)
 	}
+	r.staleWrites.record(client.ObjectKeyFromObject(sandbox), rvBefore, sandbox.ResourceVersion)
 	logger.Info("Removed pod name annotation from sandbox", "Sandbox.Name", sandbox.Name)
 	return nil
 }

--- a/controllers/sandbox_controller.go
+++ b/controllers/sandbox_controller.go
@@ -311,7 +311,9 @@ func (r *SandboxReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	// from superseded state and every write it could issue would be a no-op
 	// the apiserver still has to serve. Skip the pass; the recorded write
 	// guarantees a watch event (hence a fresh reconcile) is on its way.
-	if r.staleWrites.stillStale(req.NamespacedName, sandbox.ResourceVersion) {
+	// Only with the window enabled: the default (window 0) keeps main's
+	// reconcile path unchanged.
+	if r.TransitionalStatusWindow > 0 && r.staleWrites.stillStale(req.NamespacedName, sandbox.ResourceVersion) {
 		return ctrl.Result{}, nil
 	}
 
@@ -347,7 +349,7 @@ func (r *SandboxReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		if err := r.Patch(ctx, sandbox, patch); err != nil {
 			return ctrl.Result{}, err
 		}
-		r.staleWrites.record(req.NamespacedName, rvBefore, sandbox.ResourceVersion)
+		r.recordSandboxWrite(req.NamespacedName, rvBefore, sandbox.ResourceVersion)
 	}
 
 	oldStatus := sandbox.Status.DeepCopy()
@@ -779,7 +781,11 @@ func (r *SandboxReconciler) updateStatus(ctx context.Context, oldStatus *sandbox
 	// Ready the deferral no longer applies -- a node change on a Ready
 	// sandbox should be impossible, but if it happens, write it through
 	// rather than leave a Ready sandbox with a wrong or missing node name.
-	if nodeNameOnlyChange(oldStatus, &sandbox.Status) &&
+	// With the transitional window enabled this special case is subsumed:
+	// a nodeName-only change is transitional, so it is deferred below and
+	// flushed at age == window instead of waiting for a later write.
+	if r.TransitionalStatusWindow == 0 &&
+		nodeNameOnlyChange(oldStatus, &sandbox.Status) &&
 		!meta.IsStatusConditionTrue(sandbox.Status.Conditions, string(sandboxv1beta1.SandboxConditionReady)) {
 		return 0, nil
 	}
@@ -821,10 +827,20 @@ func (r *SandboxReconciler) updateStatus(ctx context.Context, oldStatus *sandbox
 		logger.Error(err, "Failed to patch sandbox status")
 		return 0, err
 	}
-	r.staleWrites.record(client.ObjectKeyFromObject(sandbox), rvBefore, sandbox.ResourceVersion)
+	r.recordSandboxWrite(client.ObjectKeyFromObject(sandbox), rvBefore, sandbox.ResourceVersion)
 
 	// Surface error
 	return 0, nil
+}
+
+// recordSandboxWrite notes one of this controller's own Sandbox writes for
+// the stale-cache guard. It is a no-op unless the transitional window is
+// enabled, so the default configuration keeps main's behavior exactly.
+func (r *SandboxReconciler) recordSandboxWrite(key types.NamespacedName, rvBefore, rvAfter string) {
+	if r.TransitionalStatusWindow == 0 {
+		return
+	}
+	r.staleWrites.record(key, rvBefore, rvAfter)
 }
 
 // nodeNameOnlyChange reports whether the node assignment is the only
@@ -1221,7 +1237,7 @@ func (r *SandboxReconciler) clearPodNameAnnotation(ctx context.Context, sandbox 
 	if err := r.Patch(ctx, sandbox, patch); err != nil {
 		return fmt.Errorf("failed to clear pod name annotation: %w", err)
 	}
-	r.staleWrites.record(client.ObjectKeyFromObject(sandbox), rvBefore, sandbox.ResourceVersion)
+	r.recordSandboxWrite(client.ObjectKeyFromObject(sandbox), rvBefore, sandbox.ResourceVersion)
 	logger.Info("Removed pod name annotation from sandbox", "Sandbox.Name", sandbox.Name)
 	return nil
 }

--- a/controllers/status_writes.go
+++ b/controllers/status_writes.go
@@ -125,12 +125,6 @@ func materialStatusChange(oldStatus, newStatus *sandboxv1beta1.SandboxStatus) bo
 	return false
 }
 
-// rvPair is one recorded sandbox write: the resourceVersion the write was
-// issued against and the resourceVersion it produced.
-type rvPair struct {
-	before, after string
-}
-
 // staleCacheGuard remembers, per sandbox, the resourceVersions bracketing
 // this controller's most recent write to that sandbox (main resource or
 // status). A reconcile pass whose informer copy still shows the pre-write
@@ -154,11 +148,17 @@ type rvPair struct {
 // crash or failover costs at most one redundant no-op PATCH per object.
 type staleCacheGuard struct {
 	mu sync.Mutex
-	m  map[types.NamespacedName]rvPair
+	// m holds, per key, the pre-write resourceVersions of this controller's
+	// outstanding writes. One reconcile can write twice (metadata, then
+	// status: 5->6 then 6->7), and the informer will replay 5 and 6 before
+	// 7, so every pre-write version must count as stale until an
+	// observation outside the set proves the cache has caught up.
+	m map[types.NamespacedName]map[string]struct{}
 }
 
 // record notes a successful write that moved key from rvBefore to rvAfter.
-// No-op writes (rvAfter empty or equal to rvBefore) are ignored.
+// No-op writes (rvAfter empty or equal to rvBefore) are ignored: they
+// produce no watch event that could ever clear them.
 func (g *staleCacheGuard) record(key types.NamespacedName, rvBefore, rvAfter string) {
 	if rvAfter == "" || rvAfter == rvBefore {
 		return
@@ -166,23 +166,28 @@ func (g *staleCacheGuard) record(key types.NamespacedName, rvBefore, rvAfter str
 	g.mu.Lock()
 	defer g.mu.Unlock()
 	if g.m == nil {
-		g.m = make(map[types.NamespacedName]rvPair)
+		g.m = make(map[types.NamespacedName]map[string]struct{})
 	}
-	g.m[key] = rvPair{before: rvBefore, after: rvAfter}
+	befores, ok := g.m[key]
+	if !ok {
+		befores = make(map[string]struct{}, 2)
+		g.m[key] = befores
+	}
+	befores[rvBefore] = struct{}{}
 }
 
 // stillStale reports whether a pass observing observedRV for key is running
-// behind this controller's own last write. Any observation other than the
+// behind this controller's own writes. Any observation other than a
 // recorded pre-write version proves the cache has caught up (or moved
 // further) and drops the record.
 func (g *staleCacheGuard) stillStale(key types.NamespacedName, observedRV string) bool {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	pair, ok := g.m[key]
+	befores, ok := g.m[key]
 	if !ok {
 		return false
 	}
-	if observedRV == pair.before {
+	if _, stale := befores[observedRV]; stale {
 		return true
 	}
 	delete(g.m, key)

--- a/controllers/status_writes.go
+++ b/controllers/status_writes.go
@@ -1,0 +1,197 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controllers
+
+// Status-write reduction for the Sandbox launch path.
+//
+// A healthy launch used to cost ~2.3 status writes (an initial "not Ready
+// yet" fill, sometimes an intermediate reason change, then the Ready flip)
+// plus ~0.8 no-op PATCH requests re-issued by reconciles racing the
+// controller's own informer (measured on a 100-node/50k-sandbox run:
+// 107k status PATCH requests and ~39k no-ops for 50k launches). Nothing
+// reads the transitional writes on the fast path -- consumers (the claim
+// controller, kubectl wait) act on Ready -- so this file provides:
+//
+//  1. materialStatusChange: an explicit classification of status changes
+//     into material (must write now) vs transitional (may ride along with
+//     the next material write).
+//  2. Creation-age gating (see updateStatus): with
+//     --sandbox-transitional-status-window=T, a transitional change on a
+//     sandbox younger than T is skipped and requeued to flush at age T. A
+//     launch that reaches Ready inside T writes status exactly once; a
+//     sandbox that is stuck still converges to an explanatory status at T.
+//     Like the write-behind window (writebehind_requeue.go), the deferred
+//     write is recomputed from informer state by the flushing pass, so a
+//     crash can never lose a mutation.
+//  3. staleCacheGuard: suppresses whole reconcile passes that run against
+//     an informer cache that has not yet caught up with this controller's
+//     own last sandbox write -- the source of the no-op PATCHes. The
+//     guard stores only resourceVersions, never payloads.
+
+import (
+	"sync"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	sandboxv1beta1 "sigs.k8s.io/agent-sandbox/api/v1beta1"
+)
+
+// terminalReadyReasons are Ready-condition reasons that carry terminal or
+// operator-actionable meaning even without a condition Status flip: a
+// never-Ready sandbox that expires stays Ready=False, but the expiry flow
+// (handleSandboxExpiry) only proceeds once the Expired mark is persisted,
+// and Succeeded/Failed are ends of the lifecycle, not launch progress.
+var terminalReadyReasons = map[string]bool{
+	sandboxv1beta1.SandboxReasonExpired:      true,
+	sandboxv1beta1.SandboxReasonPodFailed:    true,
+	sandboxv1beta1.SandboxReasonPodSucceeded: true,
+}
+
+// materialStatusChange reports whether the old->new status change must be
+// written immediately (material) rather than deferred (transitional).
+//
+// Material changes are the ones consumers act on:
+//   - any condition's Status VALUE changing (False->True, True->False,
+//     anything<->Unknown) -- this covers the Ready flip in both directions,
+//     Suspended taking effect, and Finished appearing (it is created with
+//     Status=True, so its very addition is material);
+//   - a condition disappearing (Finished is removed when the pod restarts);
+//   - a condition appearing with any Status other than False (the initial
+//     Ready=False / Suspended=False fill is launch progress, not news);
+//   - the Ready reason moving to or from a terminal reason (see
+//     terminalReadyReasons).
+//
+// Everything else is transitional: reason/message churn while the Status
+// value holds (Pending -> ContainerCreating), observedGeneration bumps, and
+// non-condition field fills (nodeName, podIPs, serviceFQDN, selector) --
+// all of which ride along with the next material write, where consumers
+// actually read them.
+func materialStatusChange(oldStatus, newStatus *sandboxv1beta1.SandboxStatus) bool {
+	oldConds := make(map[string]*metav1.Condition, len(oldStatus.Conditions))
+	for i := range oldStatus.Conditions {
+		oldConds[oldStatus.Conditions[i].Type] = &oldStatus.Conditions[i]
+	}
+	newSeen := make(map[string]bool, len(newStatus.Conditions))
+	for i := range newStatus.Conditions {
+		nc := &newStatus.Conditions[i]
+		newSeen[nc.Type] = true
+		oc, existed := oldConds[nc.Type]
+		if nc.Type == string(sandboxv1beta1.SandboxConditionPodScheduled) {
+			// PodScheduled mirrors the Pod's scheduling progress. Nothing on
+			// the launch path acts on Unknown or True (consumers wait for
+			// Ready), and writing the True flip on its own costs a second
+			// status write per launch. Only a move to False (unschedulable)
+			// is material: it is what an operator needs to see promptly.
+			if nc.Status == metav1.ConditionFalse && (!existed || oc.Status != metav1.ConditionFalse) {
+				return true
+			}
+			continue
+		}
+		if !existed {
+			if nc.Status != metav1.ConditionFalse {
+				return true
+			}
+			if nc.Type == string(sandboxv1beta1.SandboxConditionReady) && terminalReadyReasons[nc.Reason] {
+				return true
+			}
+			continue
+		}
+		if oc.Status != nc.Status {
+			return true
+		}
+		if nc.Type == string(sandboxv1beta1.SandboxConditionReady) && oc.Reason != nc.Reason &&
+			(terminalReadyReasons[oc.Reason] || terminalReadyReasons[nc.Reason]) {
+			return true
+		}
+	}
+	for condType := range oldConds {
+		if !newSeen[condType] {
+			return true
+		}
+	}
+	return false
+}
+
+// rvPair is one recorded sandbox write: the resourceVersion the write was
+// issued against and the resourceVersion it produced.
+type rvPair struct {
+	before, after string
+}
+
+// staleCacheGuard remembers, per sandbox, the resourceVersions bracketing
+// this controller's most recent write to that sandbox (main resource or
+// status). A reconcile pass whose informer copy still shows the pre-write
+// resourceVersion is running on state this controller has already
+// superseded: acting on it can only re-derive writes the apiserver will
+// no-op (measured: ~19% of all PATCH requests under launch load). Such a
+// pass is skipped outright -- no requeue is needed, because the recorded
+// write itself guarantees a future watch event (and therefore a fresh
+// reconcile) for the object.
+//
+// Correctness rests on resourceVersion EQUALITY only (never ordering): the
+// informer replays one object's versions in order, so observing the
+// pre-write version means the post-write event has not been delivered yet,
+// and observing anything else means it has (or a later writer has moved the
+// object on, which is equally fresh for our purposes). Writes that do not
+// change the resourceVersion (a patch the apiserver no-ops) are never
+// recorded -- recording before==after would classify every future pass as
+// stale with no event ever coming to clear it.
+//
+// Like deferredWriteClock, the map holds no mutation payload; losing it on
+// crash or failover costs at most one redundant no-op PATCH per object.
+type staleCacheGuard struct {
+	mu sync.Mutex
+	m  map[types.NamespacedName]rvPair
+}
+
+// record notes a successful write that moved key from rvBefore to rvAfter.
+// No-op writes (rvAfter empty or equal to rvBefore) are ignored.
+func (g *staleCacheGuard) record(key types.NamespacedName, rvBefore, rvAfter string) {
+	if rvAfter == "" || rvAfter == rvBefore {
+		return
+	}
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if g.m == nil {
+		g.m = make(map[types.NamespacedName]rvPair)
+	}
+	g.m[key] = rvPair{before: rvBefore, after: rvAfter}
+}
+
+// stillStale reports whether a pass observing observedRV for key is running
+// behind this controller's own last write. Any observation other than the
+// recorded pre-write version proves the cache has caught up (or moved
+// further) and drops the record.
+func (g *staleCacheGuard) stillStale(key types.NamespacedName, observedRV string) bool {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	pair, ok := g.m[key]
+	if !ok {
+		return false
+	}
+	if observedRV == pair.before {
+		return true
+	}
+	delete(g.m, key)
+	return false
+}
+
+// clear drops the record for key, if any (object deleted or gone).
+func (g *staleCacheGuard) clear(key types.NamespacedName) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	delete(g.m, key)
+}

--- a/controllers/status_writes_test.go
+++ b/controllers/status_writes_test.go
@@ -186,6 +186,24 @@ func TestUpdateStatusTransitionalWindow(t *testing.T) {
 		wantDefer bool
 	}{
 		{
+			name: "nodeName-only change on young sandbox is deferred, not dropped",
+			age:  1 * time.Second,
+			mutate: func(sb *sandboxv1beta1.Sandbox) {
+				sb.Status.NodeName = "node-1"
+			},
+			wantWrite: false,
+			wantDefer: true,
+		},
+		{
+			name: "nodeName-only change past the window is written",
+			age:  window + time.Second,
+			mutate: func(sb *sandboxv1beta1.Sandbox) {
+				sb.Status.NodeName = "node-1"
+			},
+			wantWrite: true,
+			wantDefer: false,
+		},
+		{
 			name: "transitional change on young sandbox is deferred",
 			age:  1 * time.Second,
 			mutate: func(sb *sandboxv1beta1.Sandbox) {
@@ -315,6 +333,20 @@ func TestStaleCacheGuard(t *testing.T) {
 	}
 	if g.stillStale(key, "5") {
 		t.Error("record should have been dropped after catch-up")
+	}
+
+	// Two writes in one pass (metadata 5->6, then status 6->7): the informer
+	// replays 5 and 6 before 7, and both must read as stale.
+	g.record(key, "5", "6")
+	g.record(key, "6", "7")
+	if !g.stillStale(key, "5") {
+		t.Error("first pre-write rv of a double write: stillStale = false, want true")
+	}
+	if !g.stillStale(key, "6") {
+		t.Error("second pre-write rv of a double write: stillStale = false, want true")
+	}
+	if g.stillStale(key, "7") {
+		t.Error("post-write rv of a double write: stillStale = true, want false")
 	}
 
 	// A third-party write (any rv other than pre-write) also clears.

--- a/controllers/status_writes_test.go
+++ b/controllers/status_writes_test.go
@@ -1,0 +1,346 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controllers
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	sandboxv1beta1 "sigs.k8s.io/agent-sandbox/api/v1beta1"
+)
+
+func condition(condType string, status metav1.ConditionStatus, reason string) metav1.Condition {
+	return metav1.Condition{Type: condType, Status: status, Reason: reason}
+}
+
+func statusWithConditions(conds ...metav1.Condition) *sandboxv1beta1.SandboxStatus {
+	return &sandboxv1beta1.SandboxStatus{Conditions: conds}
+}
+
+func TestMaterialStatusChange(t *testing.T) {
+	ready := string(sandboxv1beta1.SandboxConditionReady)
+	suspended := string(sandboxv1beta1.SandboxConditionSuspended)
+	finished := string(sandboxv1beta1.SandboxConditionFinished)
+	podScheduled := string(sandboxv1beta1.SandboxConditionPodScheduled)
+
+	tests := []struct {
+		name     string
+		old, new *sandboxv1beta1.SandboxStatus
+		material bool
+	}{
+		{
+			name: "initial fill: empty -> Ready=False + Suspended=False is transitional",
+			old:  &sandboxv1beta1.SandboxStatus{},
+			new: statusWithConditions(
+				condition(ready, metav1.ConditionFalse, sandboxv1beta1.SandboxReasonDependenciesNotReady),
+				condition(suspended, metav1.ConditionFalse, sandboxv1beta1.SandboxReasonNotSuspended),
+			),
+			material: false,
+		},
+		{
+			name: "PodScheduled appearing as Unknown, then flipping to True, is transitional",
+			old:  statusWithConditions(condition(ready, metav1.ConditionFalse, sandboxv1beta1.SandboxReasonDependenciesNotReady)),
+			new: statusWithConditions(
+				condition(ready, metav1.ConditionFalse, sandboxv1beta1.SandboxReasonDependenciesNotReady),
+				condition(podScheduled, metav1.ConditionUnknown, "Pending"),
+			),
+			material: false,
+		},
+		{
+			name: "PodScheduled Unknown -> True is transitional",
+			old: statusWithConditions(
+				condition(ready, metav1.ConditionFalse, sandboxv1beta1.SandboxReasonDependenciesNotReady),
+				condition(podScheduled, metav1.ConditionUnknown, "Pending"),
+			),
+			new: statusWithConditions(
+				condition(ready, metav1.ConditionFalse, sandboxv1beta1.SandboxReasonDependenciesNotReady),
+				condition(podScheduled, metav1.ConditionTrue, "Scheduled"),
+			),
+			material: false,
+		},
+		{
+			name: "PodScheduled -> False (unschedulable) is material",
+			old: statusWithConditions(
+				condition(ready, metav1.ConditionFalse, sandboxv1beta1.SandboxReasonDependenciesNotReady),
+				condition(podScheduled, metav1.ConditionUnknown, "Pending"),
+			),
+			new: statusWithConditions(
+				condition(ready, metav1.ConditionFalse, sandboxv1beta1.SandboxReasonDependenciesNotReady),
+				condition(podScheduled, metav1.ConditionFalse, "Unschedulable"),
+			),
+			material: true,
+		},
+		{
+			name:     "Ready False -> True is material",
+			old:      statusWithConditions(condition(ready, metav1.ConditionFalse, sandboxv1beta1.SandboxReasonDependenciesNotReady)),
+			new:      statusWithConditions(condition(ready, metav1.ConditionTrue, sandboxv1beta1.SandboxReasonDependenciesReady)),
+			material: true,
+		},
+		{
+			name:     "Ready True -> False (regression) is material",
+			old:      statusWithConditions(condition(ready, metav1.ConditionTrue, sandboxv1beta1.SandboxReasonDependenciesReady)),
+			new:      statusWithConditions(condition(ready, metav1.ConditionFalse, sandboxv1beta1.SandboxReasonDependenciesNotReady)),
+			material: true,
+		},
+		{
+			name:     "reason/message churn while Ready stays False is transitional",
+			old:      statusWithConditions(condition(ready, metav1.ConditionFalse, sandboxv1beta1.SandboxReasonDependenciesNotReady)),
+			new:      statusWithConditions(condition(ready, metav1.ConditionFalse, "ReconcilerError")),
+			material: false,
+		},
+		{
+			name:     "Ready reason moving to Expired is material even without a value flip",
+			old:      statusWithConditions(condition(ready, metav1.ConditionFalse, sandboxv1beta1.SandboxReasonDependenciesNotReady)),
+			new:      statusWithConditions(condition(ready, metav1.ConditionFalse, sandboxv1beta1.SandboxReasonExpired)),
+			material: true,
+		},
+		{
+			name:     "Expired appearing on a status with no prior Ready condition is material",
+			old:      &sandboxv1beta1.SandboxStatus{},
+			new:      statusWithConditions(condition(ready, metav1.ConditionFalse, sandboxv1beta1.SandboxReasonExpired)),
+			material: true,
+		},
+		{
+			name: "Finished appearing (Status=True) is material",
+			old:  statusWithConditions(condition(ready, metav1.ConditionFalse, sandboxv1beta1.SandboxReasonDependenciesNotReady)),
+			new: statusWithConditions(
+				condition(ready, metav1.ConditionFalse, sandboxv1beta1.SandboxReasonPodSucceeded),
+				condition(finished, metav1.ConditionTrue, sandboxv1beta1.SandboxReasonPodSucceeded),
+			),
+			material: true,
+		},
+		{
+			name:     "condition removal is material",
+			old:      statusWithConditions(condition(finished, metav1.ConditionTrue, sandboxv1beta1.SandboxReasonPodSucceeded)),
+			new:      &sandboxv1beta1.SandboxStatus{},
+			material: true,
+		},
+		{
+			name:     "Suspended False -> Unknown is material",
+			old:      statusWithConditions(condition(suspended, metav1.ConditionFalse, sandboxv1beta1.SandboxReasonNotSuspended)),
+			new:      statusWithConditions(condition(suspended, metav1.ConditionUnknown, sandboxv1beta1.SandboxReasonSuspendedPodStateUnknown)),
+			material: true,
+		},
+		{
+			name: "field-only fill (nodeName, podIPs, selector) is transitional",
+			old:  statusWithConditions(condition(ready, metav1.ConditionFalse, sandboxv1beta1.SandboxReasonDependenciesNotReady)),
+			new: &sandboxv1beta1.SandboxStatus{
+				Conditions:    []metav1.Condition{condition(ready, metav1.ConditionFalse, sandboxv1beta1.SandboxReasonDependenciesNotReady)},
+				NodeName:      "node-1",
+				PodIPs:        []string{"10.0.0.1"},
+				LabelSelector: "x=y",
+			},
+			material: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := materialStatusChange(tt.old, tt.new); got != tt.material {
+				t.Errorf("materialStatusChange() = %v, want %v", got, tt.material)
+			}
+		})
+	}
+}
+
+// TestUpdateStatusTransitionalWindow exercises the creation-age gating end
+// to end against the fake client: transitional changes on a young sandbox
+// are deferred (no write, positive requeue), material changes and old
+// sandboxes write through.
+func TestUpdateStatusTransitionalWindow(t *testing.T) {
+	ready := string(sandboxv1beta1.SandboxConditionReady)
+	const window = 15 * time.Second
+
+	newSandbox := func(age time.Duration) *sandboxv1beta1.Sandbox {
+		return &sandboxv1beta1.Sandbox{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "sb",
+				Namespace:         "default",
+				UID:               sandboxUID,
+				CreationTimestamp: metav1.NewTime(time.Now().Add(-age)),
+			},
+		}
+	}
+
+	tests := []struct {
+		name      string
+		age       time.Duration
+		mutate    func(*sandboxv1beta1.Sandbox)
+		wantWrite bool
+		wantDefer bool
+	}{
+		{
+			name: "transitional change on young sandbox is deferred",
+			age:  1 * time.Second,
+			mutate: func(sb *sandboxv1beta1.Sandbox) {
+				sb.Status.Conditions = []metav1.Condition{
+					condition(ready, metav1.ConditionFalse, sandboxv1beta1.SandboxReasonDependenciesNotReady),
+				}
+				sb.Status.NodeName = "node-1"
+			},
+			wantWrite: false,
+			wantDefer: true,
+		},
+		{
+			name: "material change on young sandbox writes immediately",
+			age:  1 * time.Second,
+			mutate: func(sb *sandboxv1beta1.Sandbox) {
+				sb.Status.Conditions = []metav1.Condition{
+					condition(ready, metav1.ConditionTrue, sandboxv1beta1.SandboxReasonDependenciesReady),
+				}
+			},
+			wantWrite: true,
+			wantDefer: false,
+		},
+		{
+			name: "transitional change past the window writes through",
+			age:  window + time.Second,
+			mutate: func(sb *sandboxv1beta1.Sandbox) {
+				sb.Status.Conditions = []metav1.Condition{
+					condition(ready, metav1.ConditionFalse, sandboxv1beta1.SandboxReasonDependenciesNotReady),
+				}
+				sb.Status.PodIPs = []string{"10.0.0.1"}
+			},
+			wantWrite: true,
+			wantDefer: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sb := newSandbox(tt.age)
+			fakeClient := newFakeClient(sb)
+			r := &SandboxReconciler{Client: fakeClient, TransitionalStatusWindow: window}
+
+			oldStatus := sb.Status.DeepCopy()
+			tt.mutate(sb)
+
+			wait, err := r.updateStatus(context.Background(), oldStatus, sb)
+			if err != nil {
+				t.Fatalf("updateStatus() error: %v", err)
+			}
+			if tt.wantDefer && (wait <= 0 || wait > window) {
+				t.Errorf("updateStatus() wait = %v, want in (0, %v]", wait, window)
+			}
+			if !tt.wantDefer && wait != 0 {
+				t.Errorf("updateStatus() wait = %v, want 0", wait)
+			}
+
+			stored := &sandboxv1beta1.Sandbox{}
+			if err := fakeClient.Get(context.Background(), types.NamespacedName{Namespace: "default", Name: "sb"}, stored); err != nil {
+				t.Fatalf("Get: %v", err)
+			}
+			wrote := len(stored.Status.Conditions) > 0 || stored.Status.NodeName != "" || len(stored.Status.PodIPs) > 0
+			if wrote != tt.wantWrite {
+				t.Errorf("status written = %v, want %v (stored status: %+v)", wrote, tt.wantWrite, stored.Status)
+			}
+		})
+	}
+}
+
+// TestUpdateStatusWindowDisabled verifies the default (window 0) keeps the
+// fully synchronous behavior for transitional changes.
+func TestUpdateStatusWindowDisabled(t *testing.T) {
+	sb := &sandboxv1beta1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "sb", Namespace: "default", UID: sandboxUID,
+			CreationTimestamp: metav1.Now(),
+		},
+	}
+	fakeClient := newFakeClient(sb)
+	r := &SandboxReconciler{Client: fakeClient}
+
+	oldStatus := sb.Status.DeepCopy()
+	sb.Status.Conditions = []metav1.Condition{
+		condition(string(sandboxv1beta1.SandboxConditionReady), metav1.ConditionFalse, sandboxv1beta1.SandboxReasonDependenciesNotReady),
+	}
+	// Include a second field so the change is not nodeName-only.
+	sb.Status.LabelSelector = "x=y"
+
+	wait, err := r.updateStatus(context.Background(), oldStatus, sb)
+	if err != nil {
+		t.Fatalf("updateStatus() error: %v", err)
+	}
+	if wait != 0 {
+		t.Errorf("wait = %v, want 0 with window disabled", wait)
+	}
+	stored := &sandboxv1beta1.Sandbox{}
+	if err := fakeClient.Get(context.Background(), types.NamespacedName{Namespace: "default", Name: "sb"}, stored); err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if len(stored.Status.Conditions) == 0 {
+		t.Error("status not written with window disabled")
+	}
+}
+
+func TestStaleCacheGuard(t *testing.T) {
+	key := types.NamespacedName{Namespace: "default", Name: "sb"}
+	other := types.NamespacedName{Namespace: "default", Name: "other"}
+
+	var g staleCacheGuard
+
+	// No record: never stale.
+	if g.stillStale(key, "5") {
+		t.Error("stillStale with no record = true, want false")
+	}
+
+	// Recorded write 5 -> 6: observing 5 is stale (event pending), and stays
+	// stale on repeat observation.
+	g.record(key, "5", "6")
+	if !g.stillStale(key, "5") {
+		t.Error("observing pre-write rv: stillStale = false, want true")
+	}
+	if !g.stillStale(key, "5") {
+		t.Error("repeat observation of pre-write rv: stillStale = false, want true")
+	}
+	// Observing the post-write rv clears the record.
+	if g.stillStale(key, "6") {
+		t.Error("observing post-write rv: stillStale = true, want false")
+	}
+	if g.stillStale(key, "5") {
+		t.Error("record should have been dropped after catch-up")
+	}
+
+	// A third-party write (any rv other than pre-write) also clears.
+	g.record(key, "6", "7")
+	if g.stillStale(key, "9") {
+		t.Error("observing newer third-party rv: stillStale = true, want false")
+	}
+
+	// No-op writes must not be recorded: they produce no event to clear them.
+	g.record(key, "7", "7")
+	if g.stillStale(key, "7") {
+		t.Error("no-op write recorded: every future pass would be stale forever")
+	}
+	g.record(key, "7", "")
+	if g.stillStale(key, "7") {
+		t.Error("empty rvAfter recorded")
+	}
+
+	// clear is per-key.
+	g.record(key, "7", "8")
+	g.record(other, "1", "2")
+	g.clear(key)
+	if g.stillStale(key, "7") {
+		t.Error("cleared key still stale")
+	}
+	if !g.stillStale(other, "1") {
+		t.Error("clear(key) affected other key")
+	}
+}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -13,6 +13,11 @@ The `agent-sandbox-controller` supports several command-line flags to tune perfo
 * `--kube-api-qps` (default: -1, no client-side rate limiting): Client-side QPS limit for the Kubernetes API client.
 * `--kube-api-burst` (default: 10): The maximum burst for client-side throttling of the Kubernetes API client.
 
+## Status Write Settings
+
+* `--sandbox-write-behind-window` (default: `0`, synchronous): Defer non-urgent Pod metadata patches (label/annotation drift on an already-owned Pod) for up to this long, capped at 1s, so they coalesce with the next write.
+* `--sandbox-transitional-status-window` (default: `0`, synchronous): While a Sandbox is younger than this window, skip *transitional* status writes (reason/message churn, nodeName/podIPs fills, PodScheduled Unknown/True) and write only *material* changes (condition value flips, terminal Ready reasons such as Expired/PodFailed, PodScheduled=False). A Sandbox that becomes Ready inside the window writes status exactly once; one that is stuck flushes an explanatory status once the window elapses. Also enables skipping reconcile passes whose cached Sandbox predates the controller's own last write. Recommended for high launch rates: `180s`.
+
 ## Cluster Settings
 
 * `--cluster-domain` (default: `cluster.local`): The Kubernetes cluster domain used to


### PR DESCRIPTION
## What

Adds `--sandbox-transitional-status-window=T` (default `0`, which keeps today's behavior). While a Sandbox is younger than `T`, the controller skips *transitional* status writes (reason/message churn, nodeName/podIPs fills, PodScheduled Unknown/True) and writes only *material* changes (condition value flips, terminal Ready reasons, PodScheduled=False). A launch that reaches Ready inside the window writes status exactly once, at the Ready flip. A stuck sandbox still flushes an explanatory status at age `T` via `RequeueAfter`. With the window enabled, a small `staleCacheGuard` also skips reconcile passes whose cached Sandbox predates the controller's own outstanding writes, which were only producing no-op PATCHes. With the window at its default of `0` the guard is inactive and the reconcile path is main's, unchanged.

Deferred writes are recomputed from informer state by whichever pass flushes them, so nothing is lost on crash or failover.

## Why

The controller writes Sandbox status two to four times per sandbox plus no-op re-PATCHes from reconciles racing its own informer. Nothing reads the pre-Ready writes; consumers wait on Ready. Under load those writes queue in the apiserver ahead of the Ready flips and pod status updates that readiness depends on.

## Evidence

20-cluster fleet benchmark (200 n2-standard-4 workers per cluster, 72k sandboxes per cluster created at 1,000/s, readiness taken from server-side `lastTransitionTime`). All comparisons are paired: same clusters, same day, controller swapped in place.

| clusters | controller | time to 72k Ready (s) | own fixed-60s Ready |
|---|---|---|---|
| us-east1-b, europe-west4-c, asia-southeast1-b | main | 112 / 132 / 114 | 39k / 33k / 37k |
| same | this PR without the PodScheduled rule (2.0 PATCH/launch) | 91 / 96 / 93 | 44k / 41k / 43k |
| same | **this PR**, window=180s | **75 / 76 / 75** | **59k / 58k / 59k** |
| asia-south1-b, northamerica-northeast1-a, australia-southeast1-a | main | 189 / 134 / 132 | 22k / 34k / 34k |
| same | **this PR**, window=180s | **93 / 75 / 76** | **47k / 59k / 59k** |
| us-east1-c, asia-northeast1-b, southamerica-east1-a | **this PR**, window=180s | **74 / 77 / 81** | **59k / 57k / 54k** |

With the window the clusters ready sandboxes at the create rate (the create span is 72s). main issued 3.7 status PATCHes per launch on its fastest cluster and 7.8 on its slowest, where the stale-cache feedback loop was worst.

The PodScheduled rule mattered: main's PodScheduled condition mirroring made the Unknown→True flip a second material write per launch, which cost about half the gain.

## Notes

- The default stays off. The fleet and scaleup benchmark scenarios pass `--sandbox-transitional-status-window=180s`.

