### PR TITLE
test-unit: include cluster-free e2e framework tests

### DIFF
--- a/dev/tools/test-unit
+++ b/dev/tools/test-unit
@@ -145,6 +145,8 @@ def find_go_modules(repo_root):
 def run_go_tests(repo_root, artifact_dir):
     """ runs Go unit tests in every Go module and returns the exit code """
     returncode = 0
+    # The e2e framework tests use fake clients and do not need a cluster.
+    framework_package = "sigs.k8s.io/agent-sandbox/test/e2e/framework"
 
     for module_rel in find_go_modules(repo_root):
         module_dir = os.path.join(repo_root, module_rel) if module_rel else repo_root
@@ -153,7 +155,11 @@ def run_go_tests(repo_root, artifact_dir):
             ["go", "list", "./..."], cwd=module_dir, text=True)
         packages = [
             pkg for pkg in go_list_output.strip().split('\n')
-            if pkg and "test/e2e" not in pkg
+            if pkg and (
+                "test/e2e" not in pkg
+                or pkg == framework_package
+                or pkg.startswith(framework_package + "/")
+            )
         ]
         if not packages:
             # e.g. site/ is a module only to pin the docs theme.

--- a/dev/tools/test_unit_test.py
+++ b/dev/tools/test_unit_test.py
@@ -1,0 +1,75 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for Go package selection in the unit test runner."""
+
+import importlib.util
+import os
+import sys
+import unittest
+from importlib.machinery import SourceFileLoader
+from unittest import mock
+
+_SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, _SCRIPT_DIR)
+_loader = SourceFileLoader("test_unit", os.path.join(_SCRIPT_DIR, "test-unit"))
+_spec = importlib.util.spec_from_loader("test_unit", _loader)
+test_unit = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(test_unit)
+
+
+class RunGoTestsTest(unittest.TestCase):
+    def test_includes_framework_without_running_cluster_tests(self):
+        module = "sigs.k8s.io/agent-sandbox"
+        repo_root = os.path.dirname(os.path.dirname(_SCRIPT_DIR))
+        artifact_dir = os.path.join(repo_root, "bin")
+        packages = [
+            f"{module}/controllers",
+            f"{module}/test/e2e",
+            f"{module}/test/e2e/extensions",
+            f"{module}/test/e2e/clients/python",
+            f"{module}/test/e2e/framework",
+            f"{module}/test/e2e/framework/predicates",
+            f"{module}/test/e2e/framework-extra",
+        ]
+        with (
+            mock.patch.object(test_unit.subprocess, "check_output", side_effect=[
+                "go.mod\ndev/tools/go.mod\n",
+                "\n".join(packages) + "\n",
+                f"{module}/dev/tools/mdtoc\n",
+            ]),
+            mock.patch.object(test_unit.subprocess, "run") as run,
+        ):
+            run.return_value.returncode = 0
+            self.assertEqual(test_unit.run_go_tests(repo_root, artifact_dir), 0)
+
+        self.assertEqual(run.call_args_list, [
+            mock.call(test_unit.utils.go_tool_args(
+                "gotestsum",
+                f"--junitfile={os.path.join(artifact_dir, 'junit_unit-go.xml')}",
+                "--", "-race",
+                f"{module}/controllers",
+                f"{module}/test/e2e/framework",
+                f"{module}/test/e2e/framework/predicates",
+            ), cwd=repo_root),
+            mock.call(test_unit.utils.go_tool_args(
+                "gotestsum",
+                f"--junitfile={os.path.join(artifact_dir, 'junit_unit-go-dev-tools.xml')}",
+                "--", "-race", f"{module}/dev/tools/mdtoc",
+            ), cwd=os.path.join(repo_root, "dev", "tools")),
+        ])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/dev/tools/test_unit_test.py
+++ b/dev/tools/test_unit_test.py
@@ -31,6 +31,7 @@ _spec.loader.exec_module(test_unit)
 
 class RunGoTestsTest(unittest.TestCase):
     def test_includes_framework_without_running_cluster_tests(self):
+        """Verify framework inclusion and E2E exclusion across Go modules."""
         module = "sigs.k8s.io/agent-sandbox"
         repo_root = os.path.dirname(os.path.dirname(_SCRIPT_DIR))
         artifact_dir = os.path.join(repo_root, "bin")


### PR DESCRIPTION
#### What this PR does / why we need it:

The unit test runner excludes all packages under `test/e2e`, including the framework's fake-client tests, which do not require a cluster.

Include `test/e2e/framework` and its subpackages in the unit suite so these tests run without a cluster and with the race detector enabled. Keep other E2E packages excluded.

Add regression coverage for package selection, per-module execution, and JUnit output.

#### Which issue(s) this PR is related to:

Part of #1200

#### Testing

- `python3 -m pytest dev/tools -q`: 89 passed. Confirmed that the new regression test fails with the previous package filter.
- `KUBECONFIG=/dev/null go test -race -count=1 ./test/e2e/framework/...`: passed.
- `make all`: passed with Python 3.14.7. Both framework tests appear in the Go unit test JUnit report.
- `make verify-olm-bundle`: passed.

#### Release Note

```release-note
NONE
```

<!--
=======================================================================
⚠️ CONTRIBUTOR NOTICES (Please read before submitting)
By submitting this PR, you acknowledge our [Contributing Guidelines](https://github.com/kubernetes-sigs/agent-sandbox/blob/main/CONTRIBUTING.md):

* CLA REQUIRED: You must sign the Kubernetes CLA before your PR can be reviewed.
* AI REVIEWS:
  * We use Copilot and CodeRabbit for initial reviews. Do NOT click "Commit suggestion" in the GitHub UI, as AI bots cannot sign the CLA and will block your PR. Please apply suggestions locally instead.
  * Once automated reviews finish the first pass, please resolve their comments so the PR can be labeled `ready-for-review` for maintainers!
* PR TAKEOVERS: To speed up delivery, maintainers may push final changes and directly merge your PR if it is close to completion.
* STALE POLICY: PRs inactive for 30 days are marked stale and closed 15 days later.
=======================================================================
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded Go unit-test coverage to include framework packages that run without a cluster.
  - Continued excluding end-to-end tests that require a cluster.
  - Added validation for test command execution and JUnit report output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->