### PR TITLE
perf(sandbox): requeue without error when namespace is terminating

### DIFF
--- a/controllers/errors.go
+++ b/controllers/errors.go
@@ -1,0 +1,46 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controllers
+
+import (
+	"slices"
+
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+)
+
+// joinedError is implemented by errors.Join.
+type joinedError interface {
+	Unwrap() []error
+}
+
+// isNamespaceTerminatingError reports whether err or any error in its chain
+// indicates that the namespace is terminating (e.g. 403 Forbidden with
+// NamespaceTerminating cause, or wrapping ErrNamespaceTerminating).
+func isNamespaceTerminatingError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	if joined, ok := err.(joinedError); ok {
+		return slices.ContainsFunc(joined.Unwrap(), isNamespaceTerminatingError)
+	}
+
+	if k8serrors.HasStatusCause(err, corev1.NamespaceTerminatingCause) {
+		return true
+	}
+
+	return false
+}

--- a/controllers/errors_test.go
+++ b/controllers/errors_test.go
@@ -1,0 +1,128 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controllers
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestIsNamespaceTerminatingError(t *testing.T) {
+	testCases := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "nil error",
+			err:      nil,
+			expected: false,
+		},
+		{
+			name:     "standard generic error",
+			err:      errors.New("generic error"),
+			expected: false,
+		},
+		{
+			name:     "status error with NamespaceTerminatingCause",
+			err:      newNamespaceTerminatingError("test-ns1"),
+			expected: true,
+		},
+		{
+			name:     "wrapped NamespaceTerminatingCause error",
+			err:      fmt.Errorf("reconcile failed: %w", newNamespaceTerminatingError("test-ns2")),
+			expected: true,
+		},
+		{
+			name: "status error with different cause",
+			err: &k8serrors.StatusError{
+				ErrStatus: metav1.Status{
+					Status: metav1.StatusFailure,
+					Code:   403,
+					Reason: metav1.StatusReasonForbidden,
+					Details: &metav1.StatusDetails{
+						Causes: []metav1.StatusCause{
+							{Type: metav1.CauseTypeFieldValueNotFound},
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name:     "status error without causes",
+			err:      k8serrors.NewNotFound(corev1.Resource("pods"), "test-pod"),
+			expected: false,
+		},
+		{
+			name: "joined error with NamespaceTerminating after another status error",
+			err: errors.Join(
+				k8serrors.NewNotFound(corev1.Resource("pods"), "test-pod"),
+				newNamespaceTerminatingError("test-ns"),
+			),
+			expected: true,
+		},
+		{
+			name: "joined error with wrapped NamespaceTerminating after generic error",
+			err: errors.Join(
+				errors.New("something went wrong"),
+				fmt.Errorf("wrapped: %w", newNamespaceTerminatingError("test-ns")),
+			),
+			expected: true,
+		},
+		{
+			name: "joined error without NamespaceTerminating",
+			err: errors.Join(
+				errors.New("err 1"),
+				k8serrors.NewNotFound(corev1.Resource("pods"), "test-pod"),
+			),
+			expected: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := isNamespaceTerminatingError(tc.err)
+			want := tc.expected
+			if got != want {
+				t.Errorf("%s: got %v, want %v", tc.name, got, want)
+			}
+		})
+	}
+}
+
+func newNamespaceTerminatingError(ns string) error {
+	return &k8serrors.StatusError{
+		ErrStatus: metav1.Status{
+			Status: metav1.StatusFailure,
+			Code:   403,
+			Reason: metav1.StatusReasonForbidden,
+			Details: &metav1.StatusDetails{
+				Causes: []metav1.StatusCause{
+					{
+						Type:    corev1.NamespaceTerminatingCause,
+						Message: fmt.Sprintf("unable to create new content in namespace %s because it is being terminated", ns),
+						Field:   "metadata.name",
+					},
+				},
+			},
+		},
+	}
+}

--- a/controllers/sandbox_controller.go
+++ b/controllers/sandbox_controller.go
@@ -382,9 +382,19 @@ func (r *SandboxReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			err = errors.Join(err, statusUpdateErr)
 		}
 	}
+
+	// Avoid a retry thundering-herd when we delete a namespace and the pod happens to be deleted before the sandbox.
+	if isNamespaceTerminatingError(err) {
+		return ctrl.Result{RequeueAfter: namespaceTerminatingRequeue}, nil
+	}
+
 	// return errors seen
 	return result, err
 }
+
+// namespaceTerminatingRequeue is how long to wait before re-checking a
+// Sandbox whose namespace is terminating; normally it is gone by then.
+const namespaceTerminatingRequeue = 30 * time.Second
 
 func (r *SandboxReconciler) reconcileChildResources(ctx context.Context, sandbox *sandboxv1beta1.Sandbox, wd *writeDeferral) error {
 	// Create a hash from the sandbox.Name and use it as label value

--- a/controllers/sandbox_controller_test.go
+++ b/controllers/sandbox_controller_test.go
@@ -5485,3 +5485,146 @@ func TestReconcileCoalescesNodeNameStatusWrite(t *testing.T) {
 	require.NoError(t, r.Get(t.Context(), req.NamespacedName, live))
 	assert.Equal(t, "node-2", live.Status.NodeName, "node changes on a Ready sandbox must be written immediately")
 }
+
+func TestReconcileNamespaceTerminatingRequeue(t *testing.T) {
+	testCases := []struct {
+		name      string
+		mutate    func(*sandboxv1beta1.Sandbox)
+		setupObjs func(*sandboxv1beta1.Sandbox) []runtime.Object
+		failObj   func(client.Object) bool
+	}{
+		{
+			name: "pod creation in terminating namespace requeues without error",
+			failObj: func(obj client.Object) bool {
+				_, isPod := obj.(*corev1.Pod)
+				return isPod
+			},
+		},
+		{
+			name: "pvc creation in terminating namespace requeues without error",
+			mutate: func(sb *sandboxv1beta1.Sandbox) {
+				sb.Spec.VolumeClaimTemplates = []sandboxv1beta1.PersistentVolumeClaimTemplate{
+					{
+						EmbeddedObjectMetadata: sandboxv1beta1.EmbeddedObjectMetadata{Name: "data"},
+						Spec: corev1.PersistentVolumeClaimSpec{
+							AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+						},
+					},
+				}
+			},
+			failObj: func(obj client.Object) bool {
+				_, isPVC := obj.(*corev1.PersistentVolumeClaim)
+				return isPVC
+			},
+		},
+		{
+			name: "service creation in terminating namespace requeues without error",
+			mutate: func(sb *sandboxv1beta1.Sandbox) {
+				sb.Spec.Service = new(true)
+			},
+			setupObjs: func(sb *sandboxv1beta1.Sandbox) []runtime.Object {
+				pod := &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            sb.Name,
+						Namespace:       sb.Namespace,
+						OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sb.Name)},
+						Labels:          map[string]string{sandboxLabel: NameHash(sb.Name)},
+					},
+				}
+				return []runtime.Object{pod}
+			},
+			failObj: func(obj client.Object) bool {
+				_, isSvc := obj.(*corev1.Service)
+				return isSvc
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			sb := &sandboxv1beta1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "ns-term-sb",
+					Namespace:  "terminating-ns",
+					UID:        sandboxUID,
+					Generation: 1,
+				},
+				Spec: sandboxv1beta1.SandboxSpec{
+					SandboxBlueprint: sandboxv1beta1.SandboxBlueprint{
+						PodTemplate: sandboxv1beta1.PodTemplate{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{{Name: "test-container"}},
+							},
+						},
+					},
+				},
+			}
+			if tc.mutate != nil {
+				tc.mutate(sb)
+			}
+
+			var initialObjs []runtime.Object
+			initialObjs = append(initialObjs, sb)
+			if tc.setupObjs != nil {
+				initialObjs = append(initialObjs, tc.setupObjs(sb)...)
+			}
+
+			fc := interceptor.NewClient(newFakeClient(initialObjs...), interceptor.Funcs{
+				Create: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+					if tc.failObj(obj) {
+						return newNamespaceTerminatingError(obj.GetNamespace())
+					}
+					return c.Create(ctx, obj, opts...)
+				},
+			})
+
+			r := &SandboxReconciler{
+				Client: fc,
+				Scheme: Scheme,
+				Tracer: asmetrics.NewNoOp(),
+			}
+
+			req := ctrl.Request{NamespacedName: types.NamespacedName{Name: sb.Name, Namespace: sb.Namespace}}
+			result, err := r.Reconcile(t.Context(), req)
+			require.NoError(t, err, "reconcile must not return an error when namespace is terminating")
+			assert.Equal(t, ctrl.Result{RequeueAfter: namespaceTerminatingRequeue}, result)
+		})
+	}
+}
+
+func TestReconcileNonTerminatingErrorPropagates(t *testing.T) {
+	sb := &sandboxv1beta1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "err-sb",
+			Namespace:  "default",
+			UID:        sandboxUID,
+			Generation: 1,
+		},
+		Spec: sandboxv1beta1.SandboxSpec{
+			SandboxBlueprint: sandboxv1beta1.SandboxBlueprint{
+				PodTemplate: sandboxv1beta1.PodTemplate{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{Name: "test-container"}},
+					},
+				},
+			},
+		},
+	}
+	fc := interceptor.NewClient(newFakeClient(sb), interceptor.Funcs{
+		Create: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+			if _, isPod := obj.(*corev1.Pod); isPod {
+				return k8serrors.NewInternalError(errors.New("internal server error"))
+			}
+			return c.Create(ctx, obj, opts...)
+		},
+	})
+	r := &SandboxReconciler{
+		Client: fc,
+		Scheme: Scheme,
+		Tracer: asmetrics.NewNoOp(),
+	}
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: sb.Name, Namespace: sb.Namespace}}
+	_, err := r.Reconcile(t.Context(), req)
+	require.Error(t, err, "non-terminating error must be returned to trigger retry")
+	assert.False(t, isNamespaceTerminatingError(err))
+}


### PR DESCRIPTION
### Motivation
When deleting a Kubernetes namespace containing large volumes of sandboxes (e.g. tens of thousands of sandboxes in stress or fleet scale runs), the namespace controller deletes Sandboxes and child Pods asynchronously.

When a child Pod is deleted first while the Sandbox still exists, the Sandbox reconciler attempts to re-create the child Pod. Because the namespace is terminating, `kube-apiserver` rejects the create request with `403 Forbidden` (`corev1.NamespaceTerminatingCause`). Returning this error directly pushes the Sandbox onto the exponential-backoff retry queue.

In fleet testing with 72,000 sandboxes per cluster, this produced **~670,000 errored reconciles** and an avalanche of `403 Forbidden` POST calls to the API server during namespace teardown, directly contending with the namespace controller's deletion pipeline.

### Changes
- Check `k8serrors.HasStatusCause(podErr, corev1.NamespaceTerminatingCause)` in `reconcileChildResources`.
- Return `ctrl.Result{RequeueAfter: 30 * time.Second}, nil` when the namespace is terminating instead of returning an error.
- Re-checks after 30 seconds if the sandbox outlives the namespace, without polluting retry queues or spamming API servers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

* Improved Sandbox reconciliation while its namespace is being deleted or terminated.
* Namespace-termination conditions encountered during status updates or child-resource creation now trigger an automatic retry after 30 seconds without surfacing an error.
* Prevented expected namespace-termination conditions from triggering standard error backoff, while continuing to surface unrelated errors normally.
* Improved handling of namespace-termination errors when they are wrapped or combined with other errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->