### PR TITLE
feat(dev): publish sandbox router deployment manifest in release assets

### DIFF
--- a/dev/tools/generate-release-notes
+++ b/dev/tools/generate-release-notes
@@ -307,6 +307,9 @@ kubectl apply -f https://github.com/kubernetes-sigs/agent-sandbox/releases/downl
 
 # Extensions (opt-in):
 kubectl apply -f https://github.com/kubernetes-sigs/agent-sandbox/releases/download/{tag}/extensions.yaml
+
+# Sandbox Router (optional, for routing/Kata/gVisor):
+kubectl apply -f https://github.com/kubernetes-sigs/agent-sandbox/releases/download/{tag}/sandbox-router.yaml
 ```
 
 #### Python SDK

--- a/dev/tools/release
+++ b/dev/tools/release
@@ -139,6 +139,45 @@ def check_install_manifest_drift(
         sys.exit(1)
 
 
+ROUTER_MANIFEST_FILES = (
+    "sandbox-router/deploy/serviceaccount.yaml",
+    "sandbox-router/deploy/rbac.yaml",
+    "sandbox-router/deploy/deployment.yaml",
+    "sandbox-router/deploy/service.yaml",
+    "sandbox-router/deploy/pdb.yaml",
+)
+
+
+def replace_controller_image(text, tag):
+    """Replace the ko:// image placeholder with the published controller image."""
+    image_url = f"registry.k8s.io/agent-sandbox/agent-sandbox-controller:{tag}"
+    return re.sub(
+        r"ko://sigs.k8s.io/agent-sandbox/cmd/agent-sandbox-controller.*",
+        image_url,
+        text,
+    )
+
+
+def replace_router_image(text, tag):
+    """Replace the sandbox router image with the published release tag image."""
+    image_url = f"registry.k8s.io/agent-sandbox/sandbox-router-go:{tag}"
+    return re.sub(
+        r"registry\.k8s\.io/agent-sandbox/sandbox-router-go(?::\S+)?",
+        image_url,
+        text,
+    )
+
+
+def generate_router_manifest(tag, files=ROUTER_MANIFEST_FILES):
+    """Generate the combined sandbox-router.yaml manifest with the release image tag."""
+    manifest_parts = []
+    for fname in files:
+        with open(fname) as infile:
+            manifest_parts.append(infile.read().strip())
+    combined = "\n---\n".join(manifest_parts) + "\n"
+    return replace_router_image(combined, tag)
+
+
 def main():
     parser = argparse.ArgumentParser(description="Generate release manifests.")
     parser.add_argument("--tag", required=True, help="The git tag for the release.")
@@ -168,11 +207,7 @@ def main():
 
     def replace_image(text):
         """Replace the ko:// image placeholder with the published controller image."""
-        return re.sub(
-            r"ko://sigs.k8s.io/agent-sandbox/cmd/agent-sandbox-controller.*",
-            image_url,
-            text,
-        )
+        return replace_controller_image(text, args.tag)
 
     # --- Generate sandbox.yaml (core only) ---
     print("INFO: Preparing core sandbox.yaml")
@@ -247,15 +282,24 @@ def main():
         file.write(replace_image(result.stdout))
     print("INFO: Successfully created release_assets/sandbox-with-extensions.yaml")
 
+    # --- Generate sandbox-router.yaml ---
+    print("INFO: Preparing sandbox-router.yaml")
+    router_manifest = generate_router_manifest(tag)
+    with open("release_assets/sandbox-router.yaml", "w") as file:
+        file.write(router_manifest)
+    print("INFO: Successfully created release_assets/sandbox-router.yaml")
+
     # --- Publish Draft Release ---
     if args.publish:
         print(f"INFO: Publishing draft release {tag} to GitHub...")
         core_path = "release_assets/sandbox.yaml"
         extensions_path = "release_assets/extensions.yaml"
         all_in_one_path = "release_assets/sandbox-with-extensions.yaml"
+        router_path = "release_assets/sandbox-router.yaml"
 
         if not all(
-            os.path.exists(p) for p in (core_path, extensions_path, all_in_one_path)
+            os.path.exists(p)
+            for p in (core_path, extensions_path, all_in_one_path, router_path)
         ):
             print("❌ Release assets missing. Cannot publish.")
             sys.exit(1)
@@ -276,6 +320,7 @@ def main():
                 core_path,
                 extensions_path,
                 all_in_one_path,
+                router_path,
                 "--clobber",
                 "--repo", "kubernetes-sigs/agent-sandbox",
             ])
@@ -304,6 +349,7 @@ def main():
                 core_path,
                 extensions_path,
                 all_in_one_path,
+                router_path,
             ]
 
             if notes_file:

--- a/dev/tools/release_test.py
+++ b/dev/tools/release_test.py
@@ -168,5 +168,90 @@ class CheckInstallManifestDriftTest(unittest.TestCase):
             )
 
 
+class ReplaceRouterImageTest(unittest.TestCase):
+    def test_replaces_latest_tag(self):
+        text = "image: registry.k8s.io/agent-sandbox/sandbox-router-go:latest\n"
+        got = release.replace_router_image(text, "v1.2.3")
+        self.assertEqual(
+            got,
+            "image: registry.k8s.io/agent-sandbox/sandbox-router-go:v1.2.3\n",
+        )
+
+    def test_replaces_existing_version_tag(self):
+        text = "image: registry.k8s.io/agent-sandbox/sandbox-router-go:v1.0.0\n"
+        got = release.replace_router_image(text, "v1.2.3")
+        self.assertEqual(
+            got,
+            "image: registry.k8s.io/agent-sandbox/sandbox-router-go:v1.2.3\n",
+        )
+
+    def test_leaves_unrelated_images_alone(self):
+        text = (
+            "image: registry.k8s.io/agent-sandbox/agent-sandbox-controller:v1.0.0\n"
+            "image: other-registry/sandbox-router-go:latest\n"
+        )
+        got = release.replace_router_image(text, "v1.2.3")
+        self.assertEqual(got, text)
+
+
+class GenerateRouterManifestTest(unittest.TestCase):
+    def setUp(self):
+        self._temp_files = []
+
+    def tearDown(self):
+        for p in self._temp_files:
+            if os.path.exists(p):
+                os.unlink(p)
+
+    def _create_temp_manifest(self, content):
+        tmp = tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False)
+        tmp.write(textwrap.dedent(content))
+        tmp.close()
+        self._temp_files.append(tmp.name)
+        return tmp.name
+
+    def test_combines_and_replaces_image(self):
+        f1 = self._create_temp_manifest("""
+            apiVersion: v1
+            kind: ServiceAccount
+            metadata:
+              name: sandbox-router
+        """)
+        f2 = self._create_temp_manifest("""
+            apiVersion: apps/v1
+            kind: Deployment
+            metadata:
+              name: sandbox-router
+            spec:
+              template:
+                spec:
+                  containers:
+                  - name: sandbox-router
+                    image: registry.k8s.io/agent-sandbox/sandbox-router-go:latest
+        """)
+        got = release.generate_router_manifest("v1.5.0", files=[f1, f2])
+        self.assertIn("kind: ServiceAccount", got)
+        self.assertIn("kind: Deployment", got)
+        self.assertIn("image: registry.k8s.io/agent-sandbox/sandbox-router-go:v1.5.0", got)
+        self.assertNotIn(":latest", got)
+
+    def test_default_manifest_files_exist_and_exclude_optional(self):
+        # Verify the declared ROUTER_MANIFEST_FILES exist in repo and do not
+        # include optional manifests like rbac-tokenreview, networkpolicy, or examples.
+        for path in release.ROUTER_MANIFEST_FILES:
+            self.assertTrue(
+                os.path.exists(path),
+                f"Router manifest file not found: {path}",
+            )
+        filenames = [os.path.basename(p) for p in release.ROUTER_MANIFEST_FILES]
+        self.assertNotIn("rbac-tokenreview.yaml", filenames)
+        self.assertNotIn("networkpolicy.yaml", filenames)
+        self.assertIn("serviceaccount.yaml", filenames)
+        self.assertIn("rbac.yaml", filenames)
+        self.assertIn("deployment.yaml", filenames)
+        self.assertIn("service.yaml", filenames)
+        self.assertIn("pdb.yaml", filenames)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/sandbox-router/deploy/README.md
+++ b/sandbox-router/deploy/README.md
@@ -17,14 +17,33 @@ Drop-in starting point for running the Go sandbox-router in Kubernetes. These ma
 
 ## Apply
 
+### From release assets
+
+Install the pinned release manifest (includes ServiceAccount, RBAC, Deployment, Service, and PDB):
+
 ```sh
-# Core router components
-kubectl apply -f sandbox-router/deploy/
+VERSION=$(curl -sSL https://api.github.com/repos/kubernetes-sigs/agent-sandbox/releases/latest | jq -r '.tag_name')
+kubectl apply -f https://github.com/kubernetes-sigs/agent-sandbox/releases/download/${VERSION}/sandbox-router.yaml
+```
+
+### From source
+
+```sh
+# Core router components (serviceaccount, rbac, deployment, service, pdb)
+kubectl apply -f sandbox-router/deploy/serviceaccount.yaml \
+  -f sandbox-router/deploy/rbac.yaml \
+  -f sandbox-router/deploy/deployment.yaml \
+  -f sandbox-router/deploy/service.yaml \
+  -f sandbox-router/deploy/pdb.yaml
 
 # Optional: GKE Gateway API ingress.
 # Note: GKE Standard clusters require Gateway API to be explicitly enabled
 # using --gateway-api=standard. GKE Autopilot enables it by default.
 kubectl apply -f sandbox-router/deploy/examples/gateway-gke.yaml
+
+# Optional: RBAC for TokenReview authentication
+# Only needed when running the router with --authz-mode=tokenreview.
+kubectl apply -f sandbox-router/deploy/rbac-tokenreview.yaml
 ```
 
 ## Things to change before production

--- a/site/content/docs/getting_started/install_prerequisites/_index.md
+++ b/site/content/docs/getting_started/install_prerequisites/_index.md
@@ -44,14 +44,14 @@ description: >
 
 3. Before using the client, you must deploy the `sandbox-router`. Follow these steps:
 
-   > [!WARNING]
-   > The command below disables router authentication. Use only for local testing.
+   > [!NOTE]
+   > The default deployment operates with unauthenticated routing (`--authz-mode=allow-all`). See [sandbox-router](https://github.com/kubernetes-sigs/agent-sandbox/tree/main/sandbox-router) for authentication and TLS options.
 
    ```sh
-   curl -sSL https://raw.githubusercontent.com/kubernetes-sigs/agent-sandbox/refs/tags/${VERSION}/clients/python/agentic-sandbox-client/sandbox-router/sandbox_router.yaml | sed 's|${ROUTER_IMAGE}|us-central1-docker.pkg.dev/k8s-staging-images/agent-sandbox/sandbox-router:latest-main|g' | sed '/ALLOW_UNAUTHENTICATED_ROUTER/{n;s/value: "false"/value: "true"/}' | kubectl -n agent-sandbox-system apply -f -
+   kubectl apply -f https://github.com/kubernetes-sigs/agent-sandbox/releases/download/${VERSION}/sandbox-router.yaml
 
    # Wait until all router pods are running:
-   kubectl -n agent-sandbox-system rollout status deployment/sandbox-router-deployment --timeout=90s
+   kubectl -n agent-sandbox-system rollout status deployment/sandbox-router --timeout=90s
    ```
 
 4. Create a Sandbox Template. For example the `python-runtime-sandbox`. More information about this runtime can be found [here](https://github.com/kubernetes-sigs/agent-sandbox/blob/main/examples/python-runtime-sandbox/).


### PR DESCRIPTION
#### What this PR does / why we need it:

Publishes the Go sandbox router deployment manifest (`sandbox-router.yaml`) as an official GitHub release asset.

1. Updates `dev/tools/release` to generate `release_assets/sandbox-router.yaml` by combining base manifests (`serviceaccount.yaml`, `rbac.yaml`, `deployment.yaml`, `service.yaml`, and `pdb.yaml`) while excluding optional manifests (`rbac-tokenreview.yaml`, `networkpolicy.yaml`, `examples/`).
2. Replaces `registry.k8s.io/agent-sandbox/sandbox-router-go:latest` with the matching release tag (`:${TAG}`) in `sandbox-router.yaml`.
3. Adds `sandbox-router.yaml` to the assets uploaded during release creation / publish.
4. Adds unit tests in `dev/tools/release_test.py` verifying router image replacement and default manifest generation.
5. Updates `site/content/docs/getting_started/install_prerequisites/_index.md` and `sandbox-router/deploy/README.md` to reference the release asset URL.
6. Updates `dev/tools/generate-release-notes` to include `sandbox-router.yaml` under selective installation in generated release notes.

#### Which issue(s) this PR is related to:

ref #349, #1058

#### Release Note

```release-note
Publish the Go sandbox router deployment manifest (`sandbox-router.yaml`) as an asset in GitHub releases.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Release packages now include a versioned `sandbox-router.yaml` manifest for simplified deployment.
  - Installation instructions now support applying the published router manifest directly with `kubectl`.

- **Documentation**
  - Updated sandbox-router deployment guidance with separate release and source installation paths.
  - Added instructions for optional token-review authentication configuration.
  - Clarified default unauthenticated routing behavior and provided links to authentication and TLS options.
  - Updated rollout verification to use the current deployment name.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->