### PR TITLE
fix(e2e): unblock failing e2e presubmits by repinning envd after e2b repo rename

### DIFF
--- a/examples/envd-sandbox/Dockerfile
+++ b/examples/envd-sandbox/Dockerfile
@@ -19,7 +19,8 @@
 #   docker build -t envd-sandbox:latest .
 #   docker build -t envd-sandbox:latest --build-arg ENVD_VERSION=main .
 
-# Stage 1: Build envd binary from e2b-dev/infra source.
+# Stage 1: Build envd binary from e2b-dev/runtime source (formerly e2b-dev/infra;
+# the repo was renamed and its history restructured in Sep 2026).
 # NOTE: For production use, pin ENVD_VERSION to a specific commit or release
 # tag (e.g., --build-arg ENVD_VERSION=v0.1.0 or a commit hash) instead of
 # tracking the moving `main` branch.
@@ -27,14 +28,18 @@ FROM --platform=$BUILDPLATFORM golang:1.26.2 AS builder
 
 # Pinned to a known-good commit. Override with --build-arg ENVD_VERSION=<ref>
 # to track upstream or pin to a different revision.
-ARG ENVD_VERSION=411b63edf6dea8edd265d1c5e442f41a80b76b2a
+# envd-v0.6.13 = commit 2acf2d51bd1e2fe146914f24c44f7ee07d2213c5.
+# Pin release tags rather than bare commit SHAs: upstream rebased its history
+# during the infra->runtime rename, which orphaned the previously pinned SHA
+# and broke this build (unreachable from any branch/tag).
+ARG ENVD_VERSION=envd-v0.6.13
 ARG TARGETARCH=amd64
 
 WORKDIR /src
 
-# envd lives under packages/envd in the e2b-dev/infra monorepo.
+# envd lives under packages/envd in the e2b-dev/runtime monorepo.
 # Clone then checkout supports branches, tags, and commit hashes.
-RUN git clone https://github.com/e2b-dev/infra.git /src/infra \
+RUN git clone https://github.com/e2b-dev/runtime.git /src/infra \
     && cd /src/infra \
     && git checkout ${ENVD_VERSION}
 
@@ -62,7 +67,7 @@ COPY --from=builder /out/envd /usr/local/bin/envd
 
 # Create a non-root user for subprocess execution.
 # Following the e2b-dev debug.Dockerfile pattern:
-#   https://github.com/e2b-dev/infra/blob/main/packages/envd/debug.Dockerfile
+#   https://github.com/e2b-dev/runtime/blob/main/packages/envd/debug.Dockerfile
 #
 # Security model: envd runs as root (required for PTY, process management),
 # but user code spawned via /init's defaultUser runs as this unprivileged user.

--- a/examples/envd-sandbox/Dockerfile
+++ b/examples/envd-sandbox/Dockerfile
@@ -26,13 +26,16 @@
 # tracking the moving `main` branch.
 FROM --platform=$BUILDPLATFORM golang:1.26.2 AS builder
 
-# Pinned to a known-good commit. Override with --build-arg ENVD_VERSION=<ref>
-# to track upstream or pin to a different revision.
-# envd-v0.6.13 = commit 2acf2d51bd1e2fe146914f24c44f7ee07d2213c5.
-# Pin release tags rather than bare commit SHAs: upstream rebased its history
-# during the infra->runtime rename, which orphaned the previously pinned SHA
-# and broke this build (unreachable from any branch/tag).
+# Pinned to a known-good release tag, with the resolved commit verified below.
+# Override with --build-arg ENVD_VERSION=<ref> to track upstream or pin to a
+# different revision (also override ENVD_COMMIT, or set it empty to skip the
+# commit check).
+# Tags survive upstream rebases where bare SHAs do not: the infra->runtime
+# rename rewrote history and orphaned the previously pinned SHA, breaking this
+# build. The commit check restores immutability — if upstream ever moves the
+# tag, the build fails loudly instead of silently compiling different code.
 ARG ENVD_VERSION=envd-v0.6.13
+ARG ENVD_COMMIT=2acf2d51bd1e2fe146914f24c44f7ee07d2213c5
 ARG TARGETARCH=amd64
 
 WORKDIR /src
@@ -41,7 +44,11 @@ WORKDIR /src
 # Clone then checkout supports branches, tags, and commit hashes.
 RUN git clone https://github.com/e2b-dev/runtime.git /src/infra \
     && cd /src/infra \
-    && git checkout ${ENVD_VERSION}
+    && git checkout ${ENVD_VERSION} \
+    && if [ -n "${ENVD_COMMIT}" ] && [ "$(git rev-parse HEAD)" != "${ENVD_COMMIT}" ]; then \
+         echo "ERROR: ${ENVD_VERSION} resolved to $(git rev-parse HEAD), expected ${ENVD_COMMIT} — upstream tag moved"; \
+         exit 1; \
+       fi
 
 WORKDIR /src/infra/packages/envd
 

--- a/examples/envd-sandbox/README.md
+++ b/examples/envd-sandbox/README.md
@@ -1,6 +1,6 @@
 # envd Sandbox
 
-This example demonstrates running [envd](https://github.com/e2b-dev/infra/tree/main/packages/envd) — E2B's in-sandbox daemon — as the container entrypoint inside an agent-sandbox. envd exposes an E2B-compatible REST and gRPC API on port 49983, providing filesystem operations, process execution, environment management, and metrics.
+This example demonstrates running [envd](https://github.com/e2b-dev/runtime/tree/main/packages/envd) — E2B's in-sandbox daemon — as the container entrypoint inside an agent-sandbox. envd exposes an E2B-compatible REST and gRPC API on port 49983, providing filesystem operations, process execution, environment management, and metrics.
 
 ## Overview
 
@@ -11,7 +11,7 @@ This example demonstrates running [envd](https://github.com/e2b-dev/infra/tree/m
 - **REST endpoints** — `/health`, `/metrics`, `/init`, `/envs`, `/freeze`, `/unfreeze`
 - **Port forwarding** — auto-discovers and forwards localhost ports
 
-This example builds envd from the upstream [e2b-dev/infra](https://github.com/e2b-dev/infra) source and runs it in a standard Linux container with the `--isnotfc` flag (skipping Firecracker MMDS polling). No KVM or kata-deploy is required.
+This example builds envd from the upstream [e2b-dev/runtime](https://github.com/e2b-dev/runtime) source and runs it in a standard Linux container with the `--isnotfc` flag (skipping Firecracker MMDS polling). No KVM or kata-deploy is required.
 
 The [kvcache-ai/AgentENV](https://github.com/kvcache-ai/AgentENV) project uses envd in a similar way, packaging it into an ext4 tools drive attached to Firecracker microVMs for their AI agent RL training platform.
 
@@ -136,7 +136,7 @@ All four scripts test the same operations:
 
 > **WARNING**: envd in `--isnotfc` mode runs **without authentication**. Do NOT expose port 49983 to a public network.
 
-**Security model** (following [e2b-dev design](https://github.com/e2b-dev/infra/blob/main/packages/envd/debug.Dockerfile)):
+**Security model** (following [e2b-dev design](https://github.com/e2b-dev/runtime/blob/main/packages/envd/debug.Dockerfile)):
 - **envd runs as root**: Required for PTY allocation, process management, and cgroup operations.
 - **User code runs as non-root**: The `/init` request sets `defaultUser: "user"` (uid 1000), so all user-spawned processes execute as an unprivileged user. This limits blast radius if user code is malicious.
 
@@ -174,7 +174,7 @@ kubectl delete -f <(envsubst < sandbox-envd.yaml)
 
 ## Related
 
-- [envd source](https://github.com/e2b-dev/infra/tree/main/packages/envd) — upstream E2B daemon
+- [envd source](https://github.com/e2b-dev/runtime/tree/main/packages/envd) — upstream E2B daemon
 - [kvcache-ai/AgentENV](https://github.com/kvcache-ai/AgentENV/tree/main/thirdparty/envd) — envd in Firecracker microVMs
 - [E2B docs](https://e2b.dev/docs) — E2B sandbox platform documentation
 - [firecracker-sandbox](../firecracker-sandbox/) — VM-isolated sandbox with a similar API contract


### PR DESCRIPTION
#### What this PR does / why we need it

Fixes #1621

**This PR unblocks CI: the required `presubmit-agent-sandbox-test-e2e` job is currently failing on every open PR, so nothing can merge until this lands.** Once merged, stuck PRs only need a `/retest`.


`presubmit-agent-sandbox-test-e2e` is failing on **every open PR** (all runs at base `caf20ba1`): the e2e harness builds all example images during setup, and the `envd-sandbox` image build dies in stage 1 with:

```
git checkout 411b63edf6dea8edd265d1c5e442f41a80b76b2a
fatal: unable to read tree (411b63edf6dea8edd265d1c5e442f41a80b76b2a)
```

**Root cause:** the `e2b-dev/infra` repository was renamed to `e2b-dev/runtime` and its history was restructured (Sep 2026). The old clone URL still redirects, but the bare commit SHA pinned in `ENVD_VERSION` is no longer reachable from any branch or tag, so the checkout fails and `push-images` → `deploy-kind` → the whole e2e suite aborts before a single test runs.

**Fix:** repin `ENVD_VERSION` to the upstream **release tag** `envd-v0.6.13` (= commit `2acf2d51bd1e`) — a tag survives upstream rebases, unlike a bare SHA — and point the clone URL and doc links at the renamed repository.

**Verified:**
- fresh `git clone https://github.com/e2b-dev/runtime.git && git checkout envd-v0.6.13` succeeds
- `envd` compiles at that tag with the Dockerfile's exact flags (`CGO_ENABLED=0 GOWORK=off GOTOOLCHAIN=auto go build`)
- the orphaned SHA `411b63ed…` is confirmed absent from the renamed repo

Unblocks e2e presubmits for all open PRs. Full breakage analysis in #1621.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Updates**
  - Sandbox builds now verify that the selected envd version resolves to the expected commit, preventing builds from silently using a moved tag.
  - Version override and immutability behavior are documented in the build configuration.
  - Debug configuration continues to reference the runtime repository.

- **Documentation**
  - Updated sandbox documentation, repository links, and security guidance to reference the current envd runtime repository.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
