### PR TITLE
docs: simplify installation in README with latest release downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,15 +88,14 @@ flowchart LR
 
 ### Standard Install (Core + Extensions)
 
-Recommended for most users and GitOps engines (Argo CD, Config Sync, kustomize).
-`sandbox-with-extensions.yaml` is a single, collision-free asset (the controller is
-declared once with extensions enabled):
+Recommended for most users:
 
 ```sh
-# Replace "vX.Y.Z" with a specific version tag (e.g., "v0.1.0") from
-# https://github.com/kubernetes-sigs/agent-sandbox/releases
-export VERSION="vX.Y.Z"
+# Quick install (latest release):
+kubectl apply -f https://github.com/kubernetes-sigs/agent-sandbox/releases/latest/download/sandbox-with-extensions.yaml
 
+# Or pin to a specific version (recommended for production and GitOps):
+export VERSION="v1.0.2"
 kubectl apply -f https://github.com/kubernetes-sigs/agent-sandbox/releases/download/${VERSION}/sandbox-with-extensions.yaml
 ```
 
@@ -108,10 +107,12 @@ If you prefer to install components separately:
 
 ```sh
 # Core only:
-kubectl apply -f https://github.com/kubernetes-sigs/agent-sandbox/releases/download/${VERSION}/sandbox.yaml
+kubectl apply -f https://github.com/kubernetes-sigs/agent-sandbox/releases/latest/download/sandbox.yaml
 
 # Extensions (opt-in):
-kubectl apply -f https://github.com/kubernetes-sigs/agent-sandbox/releases/download/${VERSION}/extensions.yaml
+kubectl apply -f https://github.com/kubernetes-sigs/agent-sandbox/releases/latest/download/extensions.yaml
+
+# To pin to a specific version, replace "latest/download" with "download/<version>".
 ```
 
 ### Go SDK
@@ -127,9 +128,19 @@ For detailed installation and usage instructions, please refer to the [Go SDK RE
 
 ### Python SDK
 
-To interact with the agent-sandbox programmatically, you can use the Python SDK. This client library provides a high-level interface for creating and managing sandboxes.
+To interact with the agent-sandbox programmatically from Python, use the Python SDK:
+
+```sh
+pip install k8s-agent-sandbox
+```
 
 For detailed installation and usage instructions, please refer to the [Python SDK README](clients/python/agentic-sandbox-client/README.md).
+
+### Sandbox Router (Optional)
+
+The [Sandbox Router](sandbox-router/) is an HTTP reverse proxy that routes traffic from SDKs and external clients to sandbox pods. It is useful for workloads using the Go or Python SDKs, or runtime environments (like Kata Containers and gVisor) where direct pod port-forwarding is unavailable.
+
+For deployment manifests and setup options, see [sandbox-router/deploy/](sandbox-router/deploy/).
 
 ### Verify Installation
 
@@ -161,10 +172,13 @@ kubectl get crd sandboxtemplates.extensions.agents.x-k8s.io >/dev/null 2>&1 && k
 
 > **Warning**: Deleting the CRDs will **cascade-delete all custom resources** of those types across all namespaces.
 
-Once you have confirmed no resources are in use (or you are prepared to lose them), uninstall by deleting the same manifest you used to install:
+Once you have confirmed no resources are in use (or you are prepared to lose them), uninstall by deleting the manifest for the version installed on your cluster:
 
 ```sh
-# Standard Install (Core + Extensions):
+# Set the version installed on your cluster (e.g., "v1.0.2"):
+export VERSION="v1.0.2"
+
+# Standard Install:
 kubectl delete -f https://github.com/kubernetes-sigs/agent-sandbox/releases/download/${VERSION}/sandbox-with-extensions.yaml
 
 # Or, if you used the Selective Install:


### PR DESCRIPTION
#### What this PR does / why we need it:

Simplifies the installation instructions in the root `README.md`:
1. Uses direct GitHub release download URLs (`https://github.com/kubernetes-sigs/agent-sandbox/releases/latest/download/...`) for the standard install and selective components, allowing quick one-liner installations without manually setting environment variables.
2. Preserves explicit instructions and commands for pinning to a specific release version (recommended for production and GitOps).
3. Adds `pip install k8s-agent-sandbox` command under `### Python SDK` for parity with the Go SDK section.
4. Adds a dedicated `### Sandbox Router (Optional)` section linking to `sandbox-router/` and `sandbox-router/deploy/`.
5. Simplifies uninstallation commands to match.

#### Which issue(s) this PR is related to:

#### Release Note

```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated installation instructions with latest-release commands for standard and selective installations.
  - Added optional version-pinning guidance for installing specific releases.
  - Added Python SDK installation instructions.
  - Clarified that uninstallation commands should use the version installed on the cluster.
  - Added optional Sandbox Router documentation covering its reverse-proxy role and deployment resources.
  - Improved command examples for installation, selective installation, and removal workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->