### PR TITLE
ci(e2e): scope push-images to required test images during cluster setup

### DIFF
--- a/dev/ci/presubmits/test-e2e
+++ b/dev/ci/presubmits/test-e2e
@@ -36,6 +36,20 @@ class E2ETestRunner(TestRunner):
             default="all",
         )
 
+    def setup_cluster(self, args):
+        """Build and load only the images required by the e2e test suites."""
+        return super().setup_cluster(
+            args,
+            extra_push_images_args=[
+                "--images",
+                "agent-sandbox-controller",
+                "sandbox-router",
+                "sandboxd",
+                "python-runtime-sandbox",
+                "chrome-sandbox",
+            ],
+        )
+
     def run_tests(self, args):
         # dev/tools/test-e2e writes the junit_*.xml reports straight into
         # $ARTIFACTS, so no copy_artifacts override is needed.


### PR DESCRIPTION
#### What this PR does / why we need it:
When setting up the test cluster, `dev/ci/presubmits/test-e2e` previously called `push-images` without `--images`, which defaulted to discovering and building all 21 example Dockerfiles across the repository. This caused presubmit failures whenever an unrelated example encountered build or upstream network issues (such as git tree checkout failures during third-party example image builds).

This change overrides `setup_cluster` in `E2ETestRunner` to build and load only the images required by the E2E suites:
- `agent-sandbox-controller`
- `sandbox-router`
- `sandboxd`
- `python-runtime-sandbox`
- `chrome-sandbox`

#### Which issue(s) this PR is related to:

#### Release Note
```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - End-to-end test setup now builds and loads only the container images required by the test suites, reducing unnecessary image processing and setup time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->