### PR TITLE
Harden the kwok scalability presubmit against invisible gate failures and transient infra errors

### DIFF
--- a/dev/ci/presubmits/shared/scrape_controller_metrics.py
+++ b/dev/ci/presubmits/shared/scrape_controller_metrics.py
@@ -18,6 +18,7 @@ import os
 import re
 import sys
 import urllib.request
+import xml.etree.ElementTree as ET
 
 
 def parse_histogram(metric_name, data):
@@ -64,6 +65,32 @@ def parse_histogram(metric_name, data):
     return get_percentile(0.50), get_percentile(0.90), get_percentile(0.99), int(total)
 
 
+def write_junit(path, testcases):
+    """Writes a JUnit XML report with one testcase per validated metric.
+
+    Without this, a perf-gate violation is only visible in the job stdout: the
+    ClusterLoader2 junit reports zero failures, so Spyglass/TestGrid render the
+    run as "failed before tests ran". Each entry in testcases is a
+    (name, failure_message) tuple where failure_message is None on pass.
+    """
+    failures = sum(1 for _, failure in testcases if failure)
+    suite = ET.Element(
+        "testsuite",
+        name="controller-metrics",
+        tests=str(len(testcases)),
+        failures=str(failures),
+        errors="0",
+    )
+    for name, failure in testcases:
+        case = ET.SubElement(suite, "testcase", classname="controller-metrics", name=name)
+        if failure:
+            ET.SubElement(case, "failure", message=failure).text = failure
+    parent = os.path.dirname(path)
+    if parent:
+        os.makedirs(parent, exist_ok=True)
+    ET.ElementTree(suite).write(path, encoding="utf-8", xml_declaration=True)
+
+
 def main():
     parser = argparse.ArgumentParser(description="Scrape and validate Agent Sandbox controller metrics.")
     parser.add_argument(
@@ -89,9 +116,15 @@ def main():
         default=float(os.environ.get("CL2_THRESHOLD_99_MS", 500)),
         help="Target P99 latency threshold in ms for claim adoption",
     )
+    parser.add_argument(
+        "--junit-out",
+        default=None,
+        help="Optional path for a JUnit XML report of the validated metrics",
+    )
     args = parser.parse_args()
 
     all_passed = True
+    testcases = []
 
     try:
         raw = urllib.request.urlopen(args.metrics_url, timeout=5).read().decode("utf-8")
@@ -108,6 +141,17 @@ def main():
             print(f"      P50: ~{p50:.1f} ms (Target: <= {args.threshold_50:.1f} ms){v50}")
             print(f"      P90: ~{p90:.1f} ms (Target: <= {args.threshold_90:.1f} ms){v90}")
             print(f"      P99: ~{p99:.1f} ms (Target: <= {args.threshold_99:.1f} ms){v99}")
+            for label, value, threshold in (
+                ("p50", p50, args.threshold_50),
+                ("p90", p90, args.threshold_90),
+                ("p99", p99, args.threshold_99),
+            ):
+                failure = None
+                if value > threshold:
+                    failure = (
+                        f"{label.upper()}: ~{value:.1f} ms exceeded target <= {threshold:.1f} ms"
+                    )
+                testcases.append((f"claim-adoption-latency-{label}", failure))
             if p50 > args.threshold_50 or p90 > args.threshold_90 or p99 > args.threshold_99:
                 print("      Status: [FAILED] ❌ (Latency exceeded threshold)")
                 all_passed = False
@@ -115,6 +159,9 @@ def main():
                 print("      Status: [PASSED] ✅")
         else:
             print("      Status: [FAILED] ❌ (No metrics recorded)")
+            testcases.append(
+                ("claim-adoption-latency", "No claim adoption latency metrics recorded")
+            )
             all_passed = False
 
         print("")
@@ -129,7 +176,13 @@ def main():
 
     except Exception as e:
         print(f"  Warning: Could not fetch metrics from controller: {e}")
+        testcases.append(
+            ("claim-adoption-latency", f"Could not fetch metrics from controller: {e}")
+        )
         all_passed = False
+
+    if args.junit_out:
+        write_junit(args.junit_out, testcases)
 
     if not all_passed:
         sys.exit(1)

--- a/dev/ci/presubmits/shared/test_scrape_controller_metrics.py
+++ b/dev/ci/presubmits/shared/test_scrape_controller_metrics.py
@@ -22,7 +22,11 @@ import xml.etree.ElementTree as ET
 # Make the test importable regardless of how it is invoked (pytest, unittest, etc.)
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
-from scrape_controller_metrics import parse_histogram, write_junit
+from scrape_controller_metrics import main, parse_histogram, write_junit
+
+import http.server
+import threading
+from unittest import mock
 
 
 class TestScrapeControllerMetrics(unittest.TestCase):
@@ -113,6 +117,79 @@ class TestWriteJunit(unittest.TestCase):
             write_junit(path, [("claim-adoption-latency", "No metrics recorded")])
             suite = ET.parse(path).getroot()
             self.assertEqual(suite.get("failures"), "1")
+
+
+class TestMainCLI(unittest.TestCase):
+    """End-to-end tests of main(): fetch, validate, exit code, junit."""
+
+    PASSING = (
+        'agent_sandbox_claim_controller_startup_latency_ms_bucket{le="100"} 100\n'
+        'agent_sandbox_claim_controller_startup_latency_ms_bucket{le="+Inf"} 100\n'
+    )
+    VIOLATING = (
+        'agent_sandbox_claim_controller_startup_latency_ms_bucket{le="100"} 0\n'
+        'agent_sandbox_claim_controller_startup_latency_ms_bucket{le="1000"} 100\n'
+        'agent_sandbox_claim_controller_startup_latency_ms_bucket{le="+Inf"} 100\n'
+    )
+
+    def serve(self, body):
+        class Handler(http.server.BaseHTTPRequestHandler):
+            def do_GET(self, _body=body.encode()):
+                self.send_response(200)
+                self.end_headers()
+                self.wfile.write(_body)
+
+            def log_message(self, *args):
+                pass
+
+        server = http.server.HTTPServer(("127.0.0.1", 0), Handler)
+        threading.Thread(target=server.serve_forever, daemon=True).start()
+        self.addCleanup(server.shutdown)
+        return f"http://127.0.0.1:{server.server_address[1]}/metrics"
+
+    def run_main(self, url, junit_path):
+        argv = ["scrape_controller_metrics.py", "--metrics-url", url,
+                "--threshold-50", "300", "--threshold-90", "300",
+                "--threshold-99", "500", "--junit-out", junit_path]
+        with mock.patch.object(sys, "argv", argv):
+            try:
+                main()
+            except SystemExit as e:
+                return e.code or 0
+        return 0
+
+    def junit(self, path):
+        return ET.parse(path).getroot().find(".")
+
+    def test_violation_exits_nonzero_with_failing_junit(self):
+        with tempfile.TemporaryDirectory() as d:
+            junit_path = os.path.join(d, "junit.xml")
+            code = self.run_main(self.serve(self.VIOLATING), junit_path)
+            self.assertEqual(code, 1)
+            suite = ET.parse(junit_path).getroot()
+            self.assertEqual(suite.get("failures"), "3")
+            messages = [f.get("message") for f in suite.iter("failure")]
+            self.assertTrue(any("exceeded target" in m for m in messages))
+
+    def test_metrics_unavailable_exits_nonzero_with_failing_junit(self):
+        with tempfile.TemporaryDirectory() as d:
+            junit_path = os.path.join(d, "junit.xml")
+            # Nothing listens on port 1; the fetch fails immediately.
+            code = self.run_main("http://127.0.0.1:1/metrics", junit_path)
+            self.assertEqual(code, 1)
+            suite = ET.parse(junit_path).getroot()
+            self.assertEqual(suite.get("failures"), "1")
+            (failure,) = list(suite.iter("failure"))
+            self.assertIn("Could not fetch metrics", failure.get("message"))
+
+    def test_passing_run_exits_zero_with_clean_junit(self):
+        with tempfile.TemporaryDirectory() as d:
+            junit_path = os.path.join(d, "junit.xml")
+            code = self.run_main(self.serve(self.PASSING), junit_path)
+            self.assertEqual(code, 0)
+            suite = ET.parse(junit_path).getroot()
+            self.assertEqual(suite.get("failures"), "0")
+            self.assertEqual(suite.get("tests"), "3")
 
 
 if __name__ == "__main__":

--- a/dev/ci/presubmits/shared/test_scrape_controller_metrics.py
+++ b/dev/ci/presubmits/shared/test_scrape_controller_metrics.py
@@ -15,12 +15,14 @@
 
 import os
 import sys
+import tempfile
 import unittest
+import xml.etree.ElementTree as ET
 
 # Make the test importable regardless of how it is invoked (pytest, unittest, etc.)
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
-from scrape_controller_metrics import parse_histogram
+from scrape_controller_metrics import parse_histogram, write_junit
 
 
 class TestScrapeControllerMetrics(unittest.TestCase):
@@ -66,6 +68,51 @@ agent_sandbox_claim_controller_startup_latency_ms_bucket{le="+Inf"} 0
 """
         self.assertIsNone(parse_histogram("agent_sandbox_claim_controller_startup_latency_ms", mock_data))
         self.assertIsNone(parse_histogram("agent_sandbox_claim_controller_startup_latency_ms", ""))
+
+
+class TestWriteJunit(unittest.TestCase):
+    """Unit tests for the JUnit report emitted for perf-gate results."""
+
+    def test_all_passed(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "junit_controller-metrics.xml")
+            write_junit(path, [
+                ("claim-adoption-latency-p50", None),
+                ("claim-adoption-latency-p99", None),
+            ])
+            suite = ET.parse(path).getroot()
+            self.assertEqual(suite.tag, "testsuite")
+            self.assertEqual(suite.get("tests"), "2")
+            self.assertEqual(suite.get("failures"), "0")
+            cases = suite.findall("testcase")
+            self.assertEqual(len(cases), 2)
+            for case in cases:
+                self.assertIsNone(case.find("failure"))
+
+    def test_failure_message_contains_measured_value_and_target(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "junit_controller-metrics.xml")
+            msg = "P99: ~562.5 ms exceeded target <= 500.0 ms"
+            write_junit(path, [
+                ("claim-adoption-latency-p50", None),
+                ("claim-adoption-latency-p99", msg),
+            ])
+            suite = ET.parse(path).getroot()
+            self.assertEqual(suite.get("tests"), "2")
+            self.assertEqual(suite.get("failures"), "1")
+            failed = suite.find("testcase[@name='claim-adoption-latency-p99']")
+            self.assertIsNotNone(failed)
+            failure = failed.find("failure")
+            self.assertIsNotNone(failure)
+            self.assertEqual(failure.get("message"), msg)
+            self.assertEqual(failure.text, msg)
+
+    def test_creates_missing_parent_directory(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "artifacts", "junit_controller-metrics.xml")
+            write_junit(path, [("claim-adoption-latency", "No metrics recorded")])
+            suite = ET.parse(path).getroot()
+            self.assertEqual(suite.get("failures"), "1")
 
 
 if __name__ == "__main__":

--- a/dev/ci/presubmits/test-e2e-scalability-kwok
+++ b/dev/ci/presubmits/test-e2e-scalability-kwok
@@ -183,13 +183,18 @@ CONTROLLER_PID=$!
 # `go run` compiles the controller first, which can take well over a fixed
 # sleep on a cold pod. If ClusterLoader2 starts creating claims before the
 # controller is serving, the early samples inflate the adoption-latency gate.
-echo "Waiting for controller readiness (:8082/readyz)..."
+# /readyz only proves the probe server is up (it is a healthz.Ping check);
+# reconcilers serve once leader election and cache sync finish, which
+# controller-runtime logs as "Starting workers" — wait for both. Each curl
+# probe is bounded so a wedged connection cannot outlive the loop's budget.
+echo "Waiting for controller readiness (:8082/readyz + worker startup)..."
 CONTROLLER_READY=false
 for _ in $(seq 1 60); do
   if ! kill -0 "${CONTROLLER_PID}" 2>/dev/null; then
     break
   fi
-  if curl -fsS "http://127.0.0.1:8082/readyz" >/dev/null 2>&1; then
+  if curl --connect-timeout 1 --max-time 1 -fsS "http://127.0.0.1:8082/readyz" >/dev/null 2>&1 \
+      && grep -q "Starting workers" "${WORKDIR}/controller.log"; then
     CONTROLLER_READY=true
     break
   fi

--- a/dev/ci/presubmits/test-e2e-scalability-kwok
+++ b/dev/ci/presubmits/test-e2e-scalability-kwok
@@ -60,6 +60,10 @@ echo "  Burst Duration:    ${DURATION}s"
 echo "  Controller QPS:    ${CONTROLLER_QPS} (Workers: ${CONTROLLER_WORKERS})"
 echo "======================================================="
 
+# Prow pins GOPROXY to proxy.golang.org only; keep |direct so transient proxy
+# incidents (stream errors mid-download) fall back to fetching modules directly.
+export GOPROXY="https://proxy.golang.org|direct"
+
 CACHE_DIR="${HOME}/.cache/agent-sandbox-test-bin"
 mkdir -p "${CACHE_DIR}"
 BINDIR="${CACHE_DIR}"
@@ -117,12 +121,28 @@ trap cleanup EXIT
 echo "Ensuring clean start for kwok simulated cluster..."
 "${KWOKCTL}" delete cluster --name="${CLUSTER_NAME}" 2>/dev/null || true
 
-"${KWOKCTL}" create cluster --name="${CLUSTER_NAME}" --wait=5m \
-  --runtime=binary \
-  --disable-qps-limits \
-  --extra-args="kube-apiserver=max-requests-inflight=2000" \
-  --extra-args="kube-apiserver=max-mutating-requests-inflight=1000" \
-  --extra-args="etcd=unsafe-no-fsync=true"
+# On a cold cache, `kwokctl create cluster` downloads etcd/kubernetes release
+# binaries from GitHub without retrying, so a transient 503 fails the job.
+# Retry the create (deleting the partial cluster in between) a few times.
+CREATE_OK=false
+for attempt in 1 2 3; do
+  if "${KWOKCTL}" create cluster --name="${CLUSTER_NAME}" --wait=5m \
+    --runtime=binary \
+    --disable-qps-limits \
+    --extra-args="kube-apiserver=max-requests-inflight=2000" \
+    --extra-args="kube-apiserver=max-mutating-requests-inflight=1000" \
+    --extra-args="etcd=unsafe-no-fsync=true"; then
+    CREATE_OK=true
+    break
+  fi
+  echo "kwokctl create cluster failed (attempt ${attempt}/3); retrying..."
+  "${KWOKCTL}" delete cluster --name="${CLUSTER_NAME}" 2>/dev/null || true
+  sleep 10
+done
+if [[ "${CREATE_OK}" != "true" ]]; then
+  echo "Error: kwokctl create cluster failed after 3 attempts."
+  exit 1
+fi
 
 KUBECONFIG="${WORKDIR}/kubeconfig"
 "${KWOKCTL}" get kubeconfig --name="${CLUSTER_NAME}" > "${KUBECONFIG}"
@@ -159,7 +179,28 @@ go run ./cmd/agent-sandbox-controller \
   --sandbox-template-concurrent-workers="${CONTROLLER_TEMPLATE_WORKERS}" \
   --sandbox-warm-pool-max-batch-size="${CONTROLLER_BATCH}" > "${WORKDIR}/controller.log" 2>&1 &
 CONTROLLER_PID=$!
-sleep 3
+
+# `go run` compiles the controller first, which can take well over a fixed
+# sleep on a cold pod. If ClusterLoader2 starts creating claims before the
+# controller is serving, the early samples inflate the adoption-latency gate.
+echo "Waiting for controller readiness (:8082/readyz)..."
+CONTROLLER_READY=false
+for _ in $(seq 1 60); do
+  if ! kill -0 "${CONTROLLER_PID}" 2>/dev/null; then
+    break
+  fi
+  if curl -fsS "http://127.0.0.1:8082/readyz" >/dev/null 2>&1; then
+    CONTROLLER_READY=true
+    break
+  fi
+  sleep 2
+done
+if [[ "${CONTROLLER_READY}" != "true" ]]; then
+  echo "Error: controller did not become ready within 120s. Controller log:"
+  cat "${WORKDIR}/controller.log" || true
+  exit 1
+fi
+echo "Controller is ready."
 
 CL2_REPORT_DIR="${ARTIFACTS:-.}/kwok-cl2-report"
 mkdir -p "${CL2_REPORT_DIR}"
@@ -207,7 +248,8 @@ python3 "${repo_root}/dev/ci/presubmits/shared/scrape_controller_metrics.py" \
   --metrics-url="http://127.0.0.1:8081/metrics" \
   --threshold-50="${THRESHOLD_50_MS}" \
   --threshold-90="${THRESHOLD_90_MS}" \
-  --threshold-99="${THRESHOLD_99_MS}" || SCRAPE_RC=$?
+  --threshold-99="${THRESHOLD_99_MS}" \
+  --junit-out="${ARTIFACTS:-.}/junit_controller-metrics.xml" || SCRAPE_RC=$?
 echo "======================================================="
 
 if [[ ${CL2_RC} -ne 0 ]]; then


### PR DESCRIPTION
## Motivation

RCA of all 25 real FAILURE runs on `presubmit-agent-sandbox-test-e2e-scalability-kwok` since Aug 3 (analysis: https://github.com/kubernetes-sigs/agent-sandbox/issues/1565#issuecomment-5640229437):

| Category | Count | Notes |
| --- | --- | --- |
| Clone conflicts (PR not mergeable, not lane's fault) | 13 | No action needed in this repo |
| Perf-gate violations invisible in junit | 8 | ClusterLoader2 succeeds, junit says `failures=0`, then `scrape_controller_metrics.py` fails the job with the violation printed only to stdout (e.g. `P99: ~562.5 ms (Target: <= 500.0 ms) [VIOLATION]`) — Spyglass/TestGrid render these as "failed before tests ran" |
| Real infra flakes | 2 | GitHub 503 downloading etcd inside `kwokctl create cluster` (no retry, cold cache); proxy.golang.org stream error during the CL2 `go build` (no `\|direct` fallback) |
| Caused by the PR under test | 2 | Working as intended |

## What this PR changes

1. **Perf gate emits junit** — `scrape_controller_metrics.py` gains a `--junit-out` flag (wired to `${ARTIFACTS}/junit_controller-metrics.xml` by the presubmit script) and writes one testcase per validated percentile (`claim-adoption-latency-p50/p90/p99`); failures carry the measured value vs target, and the metrics-unavailable path emits a failing testcase too. Job exit behavior is unchanged — this is purely Spyglass/TestGrid visibility, so gate violations stop registering as "failed before tests ran".
2. **Retry `kwokctl create cluster`** — bounded 3-attempt loop, deleting the partial cluster between attempts, mirroring the `curl --retry 5` the script already uses for its own kwokctl binary download. Covers the cold-cache etcd/kubernetes binary downloads GitHub occasionally 503s.
3. **GOPROXY `|direct` fallback** — the Prow job env pins proxy-only; exporting `GOPROXY="https://proxy.golang.org|direct"` lets the CL2 build and `go run` survive proxy incidents.
4. **Real readiness wait** — the `sleep 3` after launching the controller with `go run ... &` is replaced with a bounded poll (up to 120s) of the controller's `:8082/readyz` endpoint, failing loudly (dumping `controller.log`) on timeout or early process death. A cold-pod compile can exceed 3s, and CL2 starting before the controller is ready inflates the adoption-latency samples the gate measures — a plausible contributor to marginal violations like 562ms vs the 500ms target.

## Verification

- `bash -n dev/ci/presubmits/test-e2e-scalability-kwok` passes.
- Exercised `scrape_controller_metrics.py` end-to-end against a synthetic metrics server: violating fixture → exit 1 + junit with `failures="1"` and message `P99: ~666.7 ms exceeded target <= 500.0 ms`; passing fixture → exit 0 + `failures="0"`; unreachable endpoint → exit 1 + failing testcase.
- Added unit tests for the junit writer to the existing `dev/ci/presubmits/shared` suite (already wired into `make test-unit`); all 6 tests in the suite pass.

Fixes #1565


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added JUnit XML output for controller-metrics validation, including per-metric pass and failure details.
  - Reports are saved to specified output locations, including newly created directories.

- **Bug Fixes**
  - Improved scalability test reliability by retrying cluster creation after partial failures.
  - Replaced fixed startup delays with readiness checks and diagnostic logs when controllers fail to become ready.

- **Tests**
  - Added coverage for successful reports, detailed failure messages, and output directory creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->