### PR TITLE
fix(flake-report): stop counting aborted, clone-failed, and pre-test-broken runs as infra

### DIFF
--- a/dev/tools/flake-report
+++ b/dev/tools/flake-report
@@ -110,12 +110,14 @@ GCS_HTTP = "https://storage.googleapis.com"
 def column_build_id(column_ids, i):
     """Extracts the prow build ID TestGrid encodes into a column ID.
 
-    Column IDs look like '\ue000<build-id>' (possibly with more
-    U+E000-separated parts); returns None when the column has no ID.
+    Column IDs observed on live dashboards look like '\ue000<build-id>';
+    the build ID is always the final U+E000-separated part, so take the last
+    non-empty segment (robust also to a '<name>\ue000<build-id>' layout).
+    Returns None when the column has no ID.
     """
     if i >= len(column_ids) or not column_ids[i]:
         return None
-    for part in column_ids[i].split("\ue000"):
+    for part in reversed(column_ids[i].split("\ue000")):
         if part:
             return part
     return None
@@ -251,7 +253,8 @@ def analyze_tab(dashboard, tab, window):
             if cell(overall, i) not in FAIL_STATUSES:
                 continue
             col_class[i] = classify_red_run(
-                any(cell(s, i) in FAIL_STATUSES for s in test_rows.values()),
+                any(cell(s, i) in FAIL_STATUSES or cell(s, i) == FLAKY_STATUS
+                    for s in test_rows.values()),
                 any(cell(s, i) not in (0, RUNNING_STATUS)
                     for s in test_rows.values()),
                 make_artifact_fetcher(gcs_query, column_build_id(column_ids, i)),

--- a/dev/tools/flake-report
+++ b/dev/tools/flake-report
@@ -17,7 +17,10 @@
 
 Pulls recent results from the TestGrid JSON API, classifies each failing test
 as flaky (intermittent), consistently failing, or an infrastructure failure
-(the job died before tests ran), and prints a markdown report.
+(the job died before tests ran), and prints a markdown report. Red runs with
+no failing testcase are resolved against the run's GCS artifacts first:
+aborted runs, stale-PR clone failures, and pre-test PR breakage (compile,
+vet, mypy gates) are reported separately instead of being counted as infra.
 
 With --update-issues it also files or refreshes one `kind/flake` GitHub issue
 per flaky test, so the issue tracker is the durable state: reruns are
@@ -57,7 +60,7 @@ ISSUE_MARKER_PREFIX = "<!-- flake-report:test="
 INFRA_MARKER_PREFIX = "<!-- flake-report:infra-tab="
 
 
-def fetch_json(url):
+def fetch_text(url):
     # curl rather than urllib: python installs without CA bundles (common on
     # macOS) fail TLS verification, and curl is already a repo-tooling
     # prerequisite alongside gh and jq.
@@ -67,7 +70,11 @@ def fetch_json(url):
     )
     if result.returncode != 0:
         raise RuntimeError(f"fetch {url} failed: {result.stderr.strip()}")
-    return json.loads(result.stdout)
+    return result.stdout
+
+
+def fetch_json(url):
+    return json.loads(fetch_text(url))
 
 
 def gh(*args, input_text=None):
@@ -97,6 +104,100 @@ def short_name(test_name):
     return test_name.rsplit(".", 1)[-1]
 
 
+GCS_HTTP = "https://storage.googleapis.com"
+
+
+def column_build_id(column_ids, i):
+    """Extracts the prow build ID TestGrid encodes into a column ID.
+
+    Column IDs look like '\ue000<build-id>' (possibly with more
+    U+E000-separated parts); returns None when the column has no ID.
+    """
+    if i >= len(column_ids) or not column_ids[i]:
+        return None
+    for part in column_ids[i].split("\ue000"):
+        if part:
+            return part
+    return None
+
+
+def make_artifact_fetcher(gcs_query, build_id):
+    """Returns fetch(name) -> parsed JSON artifact of one prow run, or None.
+
+    pr-logs/directory tab queries don't contain the run dirs themselves;
+    each build has a pointer file naming the real gs:// location. The pointer
+    is resolved lazily and cached so a run costs at most one extra fetch.
+    """
+    cache = {}
+
+    def resolve():
+        if "dir" not in cache:
+            cache["dir"] = None
+            if "/pr-logs/directory/" in gcs_query:
+                try:
+                    pointer = fetch_text(
+                        f"{GCS_HTTP}/{gcs_query}/{build_id}.txt").strip()
+                except RuntimeError:
+                    return None
+                if pointer.startswith("gs://"):
+                    cache["dir"] = f"{GCS_HTTP}/{pointer[len('gs://'):]}"
+            else:
+                cache["dir"] = f"{GCS_HTTP}/{gcs_query}/{build_id}"
+        return cache["dir"]
+
+    def fetch(name):
+        if not build_id or not gcs_query:
+            return None
+        base = resolve()
+        if not base:
+            return None
+        try:
+            return fetch_json(f"{base}/{name}")
+        except (RuntimeError, ValueError):
+            return None
+
+    return fetch
+
+
+def classify_red_run(has_failing_test, has_test_results, fetch_artifact):
+    """Classifies why one red Overall column went red.
+
+    A red Overall cell with no failing junit testcase is not necessarily an
+    infrastructure failure: aborted runs (superseded by a newer push), stale
+    PRs that no longer merge onto main, and PRs that break a pre-test gate
+    (compile, vet, mypy) all produce the same TestGrid shape. Returns one of:
+
+      "aborted"         -- run was cancelled, not a failure at all
+      "test_failure"    -- a junit testcase failed; the per-test rows tell
+                           the story
+      "pretest_failure" -- junit exists with zero failing testcases: the PR
+                           broke a pre-test gate, author-actionable
+      "clone_failure"   -- the PR no longer merges cleanly (rebase needed)
+      "infra"           -- pod started, produced no junit, and none of the
+                           above explains the red run
+
+    fetch_artifact(name) returns the parsed JSON artifact from the run's GCS
+    dir, or None when unavailable; only artifacts needed for the verdict are
+    fetched.
+    """
+    finished = fetch_artifact("finished.json") or {}
+    if finished.get("result") == "ABORTED":
+        return "aborted"
+    if has_failing_test:
+        return "test_failure"
+    if has_test_results:
+        return "pretest_failure"
+    clone_records = fetch_artifact("clone-records.json")
+    if clone_records is not None:
+        if any(record.get("failed") for record in clone_records):
+            return "clone_failure"
+    elif finished.get("result") and not finished.get("revision"):
+        # No clone-records.json artifact at all; podutils only record
+        # "revision" in finished.json when the checkout succeeded.
+        return "clone_failure"
+    return "infra"
+
+
 def analyze_tab(dashboard, tab, window):
     """Returns (flaky, consistent, infra) findings for one TestGrid tab."""
     table = fetch_json(
@@ -121,6 +222,27 @@ def analyze_tab(dashboard, tab, window):
     def cell(statuses, i):
         return statuses[i] if i < len(statuses) else 0
 
+    # Resolve why each red run went red from its GCS artifacts. Only red
+    # Overall columns are fetched, so a mostly-green window stays cheap.
+    # Only meaningful on tabs that report per-test rows; on junit-less tabs
+    # (lint, autogen) a red run is indistinguishable from a legitimately
+    # failing PR.
+    col_class = {}
+    if overall is not None and test_rows:
+        column_ids = table.get("column_ids") or []
+        for i in range(ncols):
+            if cell(overall, i) not in FAIL_STATUSES:
+                continue
+            col_class[i] = classify_red_run(
+                any(cell(s, i) in FAIL_STATUSES for s in test_rows.values()),
+                any(cell(s, i) not in (0, RUNNING_STATUS)
+                    for s in test_rows.values()),
+                make_artifact_fetcher(gcs_query, column_build_id(column_ids, i)),
+            )
+    # Aborted runs (superseded by a newer push, or cancelled) are not
+    # failures; junit "errors" they leave behind must not count as flakes.
+    aborted_cols = {i for i, c in col_class.items() if c == "aborted"}
+
     # Columns where a large fraction of tests failed at once are a broken PR
     # or an environment-wide breakage, not per-test flakiness; exclude them
     # from flake counting so one bad run doesn't file dozens of issues.
@@ -135,7 +257,8 @@ def analyze_tab(dashboard, tab, window):
     flaky, consistent = [], []
     for name, statuses in test_rows.items():
         fail_cols = [i for i in range(ncols)
-                     if cell(statuses, i) in FAIL_STATUSES and i not in mass_cols]
+                     if cell(statuses, i) in FAIL_STATUSES
+                     and i not in mass_cols and i not in aborted_cols]
         pass_cols = [i for i in range(ncols) if cell(statuses, i) in PASS_STATUSES]
         flaky_cells = [i for i in range(ncols) if cell(statuses, i) == FLAKY_STATUS]
         if not fail_cols and not flaky_cells:
@@ -181,8 +304,11 @@ def analyze_tab(dashboard, tab, window):
         }
 
         # Recent completed results all failing => hard breakage, not a flake.
-        # RUNNING cells haven't finished, so they say nothing either way.
-        recent = [s for s in statuses if s not in (0, RUNNING_STATUS)][:3]
+        # RUNNING cells haven't finished, so they say nothing either way;
+        # aborted runs never finished either.
+        recent = [cell(statuses, i) for i in range(ncols)
+                  if i not in aborted_cols
+                  and cell(statuses, i) not in (0, RUNNING_STATUS)][:3]
         if recent and all(s in FAIL_STATUSES for s in recent):
             consistent.append(finding)
         elif (
@@ -200,32 +326,30 @@ def analyze_tab(dashboard, tab, window):
         if not any(f["test"].startswith(p + "/") for p in parents if p != f["test"])
     ]
 
-    # Infra failure: the job went red but no individual test failed in that
-    # column (cluster bring-up, image push, timeouts before junit was written).
-    # Only meaningful on tabs that report per-test rows; on junit-less tabs
-    # (lint, autogen) a red run is indistinguishable from a legitimately
-    # failing PR.
+    # Infra failure: the job started a pod, produced no junit, and was not
+    # aborted or clone-failed (cluster bring-up, image push, timeouts before
+    # junit was written). Aborted runs, stale-PR clone failures, and pre-test
+    # PR breakage produce the same red-without-failing-test TestGrid shape
+    # but are not infra; report them separately.
     infra = None
-    if overall is not None and test_rows:
-        infra_cols = [
-            i
-            for i in range(ncols)
-            if cell(overall, i) in FAIL_STATUSES
-            and not any(cell(s, i) in FAIL_STATUSES for s in test_rows.values())
-        ]
-        total_red = sum(1 for i in range(ncols) if cell(overall, i) in FAIL_STATUSES)
-        if total_red:
-            infra = {
-                "tab": tab,
-                "red_runs": total_red,
-                "infra_runs": len(infra_cols),
-                "total_runs": sum(1 for i in range(ncols) if cell(overall, i) != 0),
-                "last_failure_ts": max(
-                    (timestamps[i] for i in infra_cols if i < len(timestamps)),
-                    default=0,
-                ),
-                "job_history": job_history,
-            }
+    if col_class:
+        infra_cols = [i for i, c in col_class.items() if c == "infra"]
+        infra = {
+            "tab": tab,
+            "red_runs": len(col_class),
+            "infra_runs": len(infra_cols),
+            "aborted_runs": len(aborted_cols),
+            "clone_failures": sum(
+                1 for c in col_class.values() if c == "clone_failure"),
+            "pretest_failures": sum(
+                1 for c in col_class.values() if c == "pretest_failure"),
+            "total_runs": sum(1 for i in range(ncols) if cell(overall, i) != 0),
+            "last_failure_ts": max(
+                (timestamps[i] for i in infra_cols if i < len(timestamps)),
+                default=0,
+            ),
+            "job_history": job_history,
+        }
     return flaky, consistent, infra
 
 
@@ -264,10 +388,32 @@ def render_report(dashboard, flaky, consistent, infra, window):
         for i in infra_tabs:
             lines.append(
                 f"- {i['tab']}: {i['infra_runs']} of {i['red_runs']} red runs "
-                f"(out of {i['total_runs']} total) had no failing test — "
-                f"see {i['job_history']}"
+                f"(out of {i['total_runs']} total) died before junit was "
+                f"written — see {i['job_history']}"
             )
     else:
+        lines.append("- none")
+    lines += ["", "## Red runs excluded from infra (benign or author-actionable)"]
+    excluded_any = False
+    for i in infra:
+        if not i:
+            continue
+        if i.get("aborted_runs"):
+            lines.append(
+                f"- {i['tab']}: {i['aborted_runs']} red run(s) were aborted "
+                f"(superseded by a newer push or cancelled — not failures)")
+        if i.get("clone_failures"):
+            lines.append(
+                f"- {i['tab']}: {i['clone_failures']} red run(s) were "
+                f"stale-PR clone failures (rebase needed)")
+        if i.get("pretest_failures"):
+            lines.append(
+                f"- {i['tab']}: {i['pretest_failures']} red run(s) were "
+                f"pre-test PR breakage (compile/vet/mypy gates — "
+                f"author-actionable)")
+        excluded_any = excluded_any or any(
+            i.get(k) for k in ("aborted_runs", "clone_failures", "pretest_failures"))
+    if not excluded_any:
         lines.append("- none")
     return "\n".join(lines) + "\n"
 
@@ -390,9 +536,9 @@ def update_issues(repo, flaky, infra, dry_run):
 Job history: {i['job_history']}
 
 These are not fixed by editing tests; look at `dev/ci/shared/runner.py` retries,
-image prepulls, or job resources. Note the count is an upper bound: a PR that
-fails before tests run (e.g. does not compile) also produces a red run with no
-junit failures.
+image prepulls, or job resources. Aborted runs, stale-PR clone failures, and
+PRs that break a pre-test gate (compile/vet/mypy) are already excluded from
+this count.
 
 /kind flake
 <!-- last-reported-failure={i['last_failure_ts']} -->

--- a/dev/tools/flake-report
+++ b/dev/tools/flake-report
@@ -159,6 +159,18 @@ def make_artifact_fetcher(gcs_query, build_id):
     return fetch
 
 
+def clone_merge_conflict(record):
+    """True when a failed clone record shows a merge conflict — the stale-PR
+    shape — rather than a network or ref-fetch error. clonerefs logs the
+    git output per command; a conflicted merge always prints "CONFLICT ("
+    and "Automatic merge failed"."""
+    for cmd in record.get("commands") or []:
+        text = "%s\n%s" % (cmd.get("output", ""), cmd.get("error", ""))
+        if "Automatic merge failed" in text or "CONFLICT (" in text:
+            return True
+    return False
+
+
 def classify_red_run(has_failing_test, has_test_results, fetch_artifact):
     """Classifies why one red Overall column went red.
 
@@ -172,7 +184,9 @@ def classify_red_run(has_failing_test, has_test_results, fetch_artifact):
                            the story
       "pretest_failure" -- junit exists with zero failing testcases: the PR
                            broke a pre-test gate, author-actionable
-      "clone_failure"   -- the PR no longer merges cleanly (rebase needed)
+      "clone_failure"   -- the PR no longer merges cleanly onto main: a
+                           merge conflict verified in clone-records.json
+                           (rebase needed)
       "infra"           -- pod started, produced no junit, and none of the
                            above explains the red run
 
@@ -189,12 +203,15 @@ def classify_red_run(has_failing_test, has_test_results, fetch_artifact):
         return "pretest_failure"
     clone_records = fetch_artifact("clone-records.json")
     if clone_records is not None:
-        if any(record.get("failed") for record in clone_records):
-            return "clone_failure"
-    elif finished.get("result") and not finished.get("revision"):
-        # No clone-records.json artifact at all; podutils only record
-        # "revision" in finished.json when the checkout succeeded.
-        return "clone_failure"
+        failed = [r for r in clone_records if r.get("failed")]
+        if failed:
+            if any(clone_merge_conflict(r) for r in failed):
+                return "clone_failure"
+            # The clone failed without a merge conflict (network error,
+            # unreachable ref): that is infrastructure, not a stale PR.
+            return "infra"
+    # Without clone-records.json the cause of a junit-less red run cannot
+    # be proven benign, so it stays in the infra count.
     return "infra"
 
 
@@ -259,8 +276,12 @@ def analyze_tab(dashboard, tab, window):
         fail_cols = [i for i in range(ncols)
                      if cell(statuses, i) in FAIL_STATUSES
                      and i not in mass_cols and i not in aborted_cols]
-        pass_cols = [i for i in range(ncols) if cell(statuses, i) in PASS_STATUSES]
-        flaky_cells = [i for i in range(ncols) if cell(statuses, i) == FLAKY_STATUS]
+        pass_cols = [i for i in range(ncols)
+                     if cell(statuses, i) in PASS_STATUSES
+                     and i not in aborted_cols]
+        flaky_cells = [i for i in range(ncols)
+                       if cell(statuses, i) == FLAKY_STATUS
+                       and i not in aborted_cols]
         if not fail_cols and not flaky_cells:
             continue
 

--- a/dev/tools/flake_report_test.py
+++ b/dev/tools/flake_report_test.py
@@ -66,21 +66,44 @@ class ClassifyRedRunTest(unittest.TestCase):
             artifacts(finished={"result": "FAILURE", "revision": "abc"}))
         self.assertEqual(cls, "pretest_failure")
 
-    def test_clone_record_failed_is_a_clone_failure(self):
+    def test_clone_merge_conflict_is_a_clone_failure(self):
         cls = flake_report.classify_red_run(
             False, False,
             artifacts(
                 finished={"result": "FAILURE"},
-                clone_records=[{"refs": {"repo": ""}},
-                               {"refs": {"repo": "agent-sandbox"}, "failed": True}],
+                clone_records=[
+                    {"refs": {"repo": ""}},
+                    {"refs": {"repo": "agent-sandbox"}, "failed": True,
+                     "commands": [{"command": "git merge --no-ff abc",
+                                   "output": "CONFLICT (content): Merge "
+                                             "conflict in examples/README.md\n"
+                                             "Automatic merge failed",
+                                   "error": "exit status 1"}]},
+                ],
             ))
         self.assertEqual(cls, "clone_failure")
 
-    def test_missing_clone_records_with_no_revision_is_a_clone_failure(self):
-        # finished.json only records "revision" when the checkout succeeded.
+    def test_clone_failed_without_conflict_is_infra(self):
+        # clonerefs also sets failed=true on network/ref-fetch errors; only
+        # a verified merge conflict may be blamed on a stale PR.
+        cls = flake_report.classify_red_run(
+            False, False,
+            artifacts(
+                finished={"result": "FAILURE"},
+                clone_records=[
+                    {"refs": {"repo": "agent-sandbox"}, "failed": True,
+                     "commands": [{"command": "git fetch origin",
+                                   "output": "",
+                                   "error": "connection timed out"}]},
+                ],
+            ))
+        self.assertEqual(cls, "infra")
+
+    def test_missing_clone_records_with_no_revision_stays_infra(self):
+        # Without clone-records.json the cause cannot be proven benign.
         cls = flake_report.classify_red_run(
             False, False, artifacts(finished={"result": "FAILURE"}))
-        self.assertEqual(cls, "clone_failure")
+        self.assertEqual(cls, "infra")
 
     def test_no_junit_clean_clone_is_infra(self):
         cls = flake_report.classify_red_run(
@@ -204,7 +227,9 @@ class AnalyzeTabTest(unittest.TestCase):
     ARTIFACTS = {
         "b0": {"finished.json": {"result": "ABORTED"}},
         "b1": {"finished.json": {"result": "FAILURE"},
-               "clone-records.json": [{"failed": True}]},
+               "clone-records.json": [
+                   {"failed": True,
+                    "commands": [{"output": "Automatic merge failed"}]}]},
         "b2": {"finished.json": {"result": "FAILURE", "revision": "abc"}},
         "b3": {"finished.json": {"result": "FAILURE", "revision": "abc"},
                "clone-records.json": [{"failed": False}]},
@@ -247,6 +272,41 @@ class AnalyzeTabTest(unittest.TestCase):
         self.assertEqual(finding["fails"], 1)
         self.assertEqual(finding["last_failure_ts"], 200)
         self.assertEqual(finding["retest_flips"], 1)
+
+    def test_aborted_pass_does_not_create_a_retest_flip(self):
+        # TestP fails on changelist c1 and "passes" only inside the aborted
+        # rerun of the same changelist; that pass must not count as a flip.
+        table = {
+            "query": "kubernetes-ci-logs/pr-logs/directory/job",
+            "changelists": ["c1", "c1", "c2"],
+            "column_ids": ["\ue000a0", "\ue000a1", "\ue000a2"],
+            "timestamps": [300, 200, 100],
+            "tests": [
+                {"name": "job.Overall", "statuses": rle([12, 12, 1])},
+                {"name": "pkg.TestP", "statuses": rle([1, 12, 1])},
+                {"name": "pkg.TestQ", "statuses": rle([13, 1, 1])},
+            ],
+        }
+        art = {"a0": {"finished.json": {"result": "ABORTED"}},
+               "a1": {"finished.json": {"result": "FAILURE",
+                                        "revision": "abc"}}}
+
+        def fake_fetcher(gcs_query, build_id):
+            return lambda name: art.get(build_id, {}).get(name)
+
+        with mock.patch.object(flake_report, "fetch_json",
+                               return_value=table), \
+             mock.patch.object(flake_report, "make_artifact_fetcher",
+                               fake_fetcher):
+            flaky, consistent, _ = flake_report.analyze_tab("dash", "tab", 3)
+        findings = {f["test"]: f for f in flaky + consistent}
+        # TestP: one real failure on a single changelist. Before the fix the
+        # aborted rerun's pass counted as a retest flip, promoting it to a
+        # reported flake; now it is correctly treated as that PR's own bug.
+        self.assertNotIn("pkg.TestP", findings)
+        # TestQ: its only flaky cell sits in the aborted column, so it must
+        # not be reported at all.
+        self.assertNotIn("pkg.TestQ", findings)
 
     def test_render_report_calls_out_benign_red_runs(self):
         flaky, consistent, infra = self.analyze()

--- a/dev/tools/flake_report_test.py
+++ b/dev/tools/flake_report_test.py
@@ -133,6 +133,12 @@ class ClassifyRedRunTest(unittest.TestCase):
 
 
 class ColumnBuildIdTest(unittest.TestCase):
+    def test_takes_last_segment_when_id_carries_a_name_prefix(self):
+        # Live dashboards emit '\ue000<build-id>', but be robust to a
+        # '<name>\ue000<build-id>' layout too: the build ID is always last.
+        self.assertEqual(
+            flake_report.column_build_id(["job\ue000123"], 0), "123")
+
     def test_strips_testgrid_id_prefix(self):
         self.assertEqual(
             flake_report.column_build_id(["\ue0002098490053683580928"], 0),
@@ -307,6 +313,34 @@ class AnalyzeTabTest(unittest.TestCase):
         # TestQ: its only flaky cell sits in the aborted column, so it must
         # not be reported at all.
         self.assertNotIn("pkg.TestQ", findings)
+
+    def test_flaky_cell_is_a_test_story_not_pretest_breakage(self):
+        # FLAKY_STATUS records a real failure (failed, then passed on a
+        # rerun of the same column); a red run whose only failure is a
+        # flaky cell must not be reported as pre-test PR breakage.
+        table = {
+            "query": "kubernetes-ci-logs/pr-logs/directory/job",
+            "changelists": ["f0", "f1"],
+            "column_ids": ["\ue000f0", "\ue000f1"],
+            "timestamps": [200, 100],
+            "tests": [
+                {"name": "job.Overall", "statuses": rle([12, 1])},
+                {"name": "pkg.TestF", "statuses": rle([13, 1])},
+            ],
+        }
+        art = {"f0": {"finished.json": {"result": "FAILURE",
+                                        "revision": "abc"}}}
+
+        def fake_fetcher(gcs_query, build_id):
+            return lambda name: art.get(build_id, {}).get(name)
+
+        with mock.patch.object(flake_report, "fetch_json",
+                               return_value=table), \
+             mock.patch.object(flake_report, "make_artifact_fetcher",
+                               fake_fetcher):
+            _, _, infra = flake_report.analyze_tab("dash", "tab", 2)
+        self.assertEqual(infra["pretest_failures"], 0)
+        self.assertEqual(infra["infra_runs"], 0)
 
     def test_render_report_calls_out_benign_red_runs(self):
         flaky, consistent, infra = self.analyze()

--- a/dev/tools/flake_report_test.py
+++ b/dev/tools/flake_report_test.py
@@ -1,0 +1,262 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for flake-report — red-run classification and infra counting."""
+
+import importlib.util
+import os
+import sys
+import unittest
+from importlib.machinery import SourceFileLoader
+from unittest import mock
+
+# Load the extensionless flake-report script via importlib (same pattern as
+# dev/tools/latest_published_tag_test.py).
+_SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, _SCRIPT_DIR)
+
+_SCRIPT_PATH = os.path.join(_SCRIPT_DIR, "flake-report")
+_loader = SourceFileLoader("flake_report", _SCRIPT_PATH)
+_spec = importlib.util.spec_from_loader("flake_report", _loader)
+flake_report = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(flake_report)
+
+
+def artifacts(**files):
+    """fetch_artifact stand-in serving canned finished.json etc. per name."""
+    data = {name.replace("_", "-") + ".json": value for name, value in files.items()}
+    return data.get
+
+
+class ClassifyRedRunTest(unittest.TestCase):
+    def test_aborted_run_is_not_a_failure(self):
+        cls = flake_report.classify_red_run(
+            False, False, artifacts(finished={"result": "ABORTED"}))
+        self.assertEqual(cls, "aborted")
+
+    def test_aborted_wins_even_with_junit_errors(self):
+        # A run cancelled mid-flight can leave junit "errors" behind; the
+        # tests it killed must not be tallied as flakes.
+        cls = flake_report.classify_red_run(
+            True, True, artifacts(finished={"result": "ABORTED"}))
+        self.assertEqual(cls, "aborted")
+
+    def test_failing_testcase_is_a_test_failure(self):
+        cls = flake_report.classify_red_run(
+            True, True,
+            artifacts(finished={"result": "FAILURE", "revision": "abc"}))
+        self.assertEqual(cls, "test_failure")
+
+    def test_junit_with_no_failing_testcase_is_pretest_breakage(self):
+        # mypy/vet/compile gates fail after junit was written: the job goes
+        # red with a clean junit — the PR's own breakage, not infra.
+        cls = flake_report.classify_red_run(
+            False, True,
+            artifacts(finished={"result": "FAILURE", "revision": "abc"}))
+        self.assertEqual(cls, "pretest_failure")
+
+    def test_clone_record_failed_is_a_clone_failure(self):
+        cls = flake_report.classify_red_run(
+            False, False,
+            artifacts(
+                finished={"result": "FAILURE"},
+                clone_records=[{"refs": {"repo": ""}},
+                               {"refs": {"repo": "agent-sandbox"}, "failed": True}],
+            ))
+        self.assertEqual(cls, "clone_failure")
+
+    def test_missing_clone_records_with_no_revision_is_a_clone_failure(self):
+        # finished.json only records "revision" when the checkout succeeded.
+        cls = flake_report.classify_red_run(
+            False, False, artifacts(finished={"result": "FAILURE"}))
+        self.assertEqual(cls, "clone_failure")
+
+    def test_no_junit_clean_clone_is_infra(self):
+        cls = flake_report.classify_red_run(
+            False, False,
+            artifacts(
+                finished={"result": "FAILURE", "revision": "abc"},
+                clone_records=[{"refs": {"repo": "agent-sandbox"}}],
+            ))
+        self.assertEqual(cls, "infra")
+
+    def test_unfetchable_artifacts_stay_infra(self):
+        # When GCS gives us nothing we cannot prove a benign cause; keep the
+        # pre-existing conservative behavior.
+        cls = flake_report.classify_red_run(False, False, lambda name: None)
+        self.assertEqual(cls, "infra")
+
+    def test_clone_records_not_fetched_when_junit_present(self):
+        fetched = []
+
+        def fetch(name):
+            fetched.append(name)
+            return {"result": "FAILURE", "revision": "abc"} \
+                if name == "finished.json" else None
+
+        flake_report.classify_red_run(False, True, fetch)
+        self.assertEqual(fetched, ["finished.json"])
+
+
+class ColumnBuildIdTest(unittest.TestCase):
+    def test_strips_testgrid_id_prefix(self):
+        self.assertEqual(
+            flake_report.column_build_id(["\ue0002098490053683580928"], 0),
+            "2098490053683580928")
+
+    def test_missing_or_empty_columns(self):
+        self.assertIsNone(flake_report.column_build_id([], 0))
+        self.assertIsNone(flake_report.column_build_id([""], 0))
+        self.assertIsNone(flake_report.column_build_id(["\ue000"], 0))
+
+
+class MakeArtifactFetcherTest(unittest.TestCase):
+    def test_resolves_pr_logs_directory_pointer(self):
+        urls = []
+
+        def fake_fetch_text(url):
+            urls.append(url)
+            return "gs://bucket/pr-logs/pull/org_repo/1/job/123\n"
+
+        def fake_fetch_json(url):
+            urls.append(url)
+            return {"result": "FAILURE"}
+
+        with mock.patch.object(flake_report, "fetch_text", fake_fetch_text), \
+             mock.patch.object(flake_report, "fetch_json", fake_fetch_json):
+            fetch = flake_report.make_artifact_fetcher(
+                "bucket/pr-logs/directory/job", "123")
+            self.assertEqual(fetch("finished.json"), {"result": "FAILURE"})
+            # The pointer is cached: a second artifact costs one fetch.
+            fetch("clone-records.json")
+        self.assertEqual(urls, [
+            "https://storage.googleapis.com/bucket/pr-logs/directory/job/123.txt",
+            "https://storage.googleapis.com/bucket/pr-logs/pull/org_repo/1/job/123/finished.json",
+            "https://storage.googleapis.com/bucket/pr-logs/pull/org_repo/1/job/123/clone-records.json",
+        ])
+
+    def test_periodic_logs_path_needs_no_pointer(self):
+        urls = []
+
+        def fake_fetch_json(url):
+            urls.append(url)
+            return {"result": "ABORTED"}
+
+        with mock.patch.object(flake_report, "fetch_json", fake_fetch_json):
+            fetch = flake_report.make_artifact_fetcher("bucket/logs/job", "456")
+            self.assertEqual(fetch("finished.json"), {"result": "ABORTED"})
+        self.assertEqual(
+            urls, ["https://storage.googleapis.com/bucket/logs/job/456/finished.json"])
+
+    def test_returns_none_without_build_id_or_on_fetch_error(self):
+        fetch = flake_report.make_artifact_fetcher("bucket/logs/job", None)
+        self.assertIsNone(fetch("finished.json"))
+
+        def boom(url):
+            raise RuntimeError("404")
+
+        with mock.patch.object(flake_report, "fetch_json", boom):
+            fetch = flake_report.make_artifact_fetcher("bucket/logs/job", "456")
+            self.assertIsNone(fetch("finished.json"))
+
+
+def rle(values):
+    return [{"value": v, "count": 1} for v in values]
+
+
+class AnalyzeTabTest(unittest.TestCase):
+    """analyze_tab with a canned TestGrid table and canned GCS artifacts.
+
+    Six columns, newest first:
+      0: aborted run that also left junit errors behind
+      1: stale-PR clone failure (no junit)
+      2: pre-test PR breakage (junit present, nothing failed, job red)
+      3: true infra failure (no junit, clone fine)
+      4: real test failure of TestA
+      5: green run (TestA passed on a bare retest of column 4's PR)
+    """
+
+    TABLE = {
+        "query": "kubernetes-ci-logs/pr-logs/directory/job",
+        "changelists": ["b0", "b1", "b2", "b3", "b4", "b4"],
+        "column_ids": ["\ue000b0", "\ue000b1", "\ue000b2",
+                       "\ue000b3", "\ue000b4", "\ue000b5"],
+        "timestamps": [600, 500, 400, 300, 200, 100],
+        "tests": [
+            {"name": "job.Overall", "statuses": rle([12, 12, 12, 12, 12, 1])},
+            {"name": "job.Pod", "statuses": rle([12, 12, 12, 12, 12, 1])},
+            {"name": "pkg.TestA", "statuses": rle([12, 0, 1, 0, 12, 1])},
+            {"name": "pkg.TestB", "statuses": rle([0, 0, 1, 0, 1, 1])},
+        ],
+    }
+
+    ARTIFACTS = {
+        "b0": {"finished.json": {"result": "ABORTED"}},
+        "b1": {"finished.json": {"result": "FAILURE"},
+               "clone-records.json": [{"failed": True}]},
+        "b2": {"finished.json": {"result": "FAILURE", "revision": "abc"}},
+        "b3": {"finished.json": {"result": "FAILURE", "revision": "abc"},
+               "clone-records.json": [{"failed": False}]},
+        "b4": {"finished.json": {"result": "FAILURE", "revision": "abc"}},
+    }
+
+    def analyze(self):
+        def fake_fetcher(gcs_query, build_id):
+            return lambda name: self.ARTIFACTS.get(build_id, {}).get(name)
+
+        with mock.patch.object(flake_report, "fetch_json",
+                               return_value=self.TABLE), \
+             mock.patch.object(flake_report, "make_artifact_fetcher",
+                               fake_fetcher):
+            return flake_report.analyze_tab("dash", "tab", 6)
+
+    def test_red_runs_split_into_causes(self):
+        _, _, infra = self.analyze()
+        self.assertEqual(infra["red_runs"], 5)
+        self.assertEqual(infra["infra_runs"], 1)
+        self.assertEqual(infra["aborted_runs"], 1)
+        self.assertEqual(infra["clone_failures"], 1)
+        self.assertEqual(infra["pretest_failures"], 1)
+        self.assertEqual(infra["total_runs"], 6)
+        # The only infra column is 3.
+        self.assertEqual(infra["last_failure_ts"], 300)
+        # Existing consumers of --json rely on these keys.
+        self.assertLessEqual(
+            {"tab", "red_runs", "infra_runs", "total_runs",
+             "last_failure_ts", "job_history"},
+            set(infra))
+
+    def test_aborted_junit_errors_do_not_count_as_flakes(self):
+        flaky, consistent, _ = self.analyze()
+        self.assertEqual(consistent, [])
+        (finding,) = flaky
+        self.assertEqual(finding["test"], "pkg.TestA")
+        # Column 0 failed inside an aborted run and must not be tallied:
+        # only column 4 counts, and the newest real failure is at ts=200.
+        self.assertEqual(finding["fails"], 1)
+        self.assertEqual(finding["last_failure_ts"], 200)
+        self.assertEqual(finding["retest_flips"], 1)
+
+    def test_render_report_calls_out_benign_red_runs(self):
+        flaky, consistent, infra = self.analyze()
+        report = flake_report.render_report("dash", flaky, consistent, [infra], 6)
+        self.assertIn("1 red run(s) were stale-PR clone failures (rebase needed)",
+                      report)
+        self.assertIn("pre-test PR breakage", report)
+        self.assertIn("were aborted", report)
+        self.assertIn("1 of 5 red runs", report)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What was wrong

`analyze_tab()` in `dev/tools/flake-report` classified every red Overall column with no failing junit testcase as an infrastructure failure. Three benign run shapes produce that exact TestGrid signature and were all miscounted as infra:

1. **Aborted runs** — the trigger plugin cancels an in-flight job when a newer push to the PR supersedes it (`finished.json` says `"result": "ABORTED"`). Not a failure at all.
2. **Stale-PR clone failures** — the PR no longer merges onto main (`clone-records.json` has `"failed": true`). Author-actionable: rebase needed.
3. **Pre-test PR breakage** — junit exists with zero failing testcases, but a compile/vet/mypy gate broke: the PR's own bug.

## Evidence

Verified against the full Prow GCS history (see the analysis comments on the trackers this heuristic filed):

- #1566 (`presubmit-test-unit`): [analysis](https://github.com/kubernetes-sigs/agent-sandbox/issues/1566#issuecomment-5640228528) — the reported "49 infra runs" were 35 trigger-plugin ABORTED runs + 7 clonerefs merge conflicts + 7 PR-caused pre-test failures. Zero real infra failures.
- #1565 (kwok scalability lane): [analysis](https://github.com/kubernetes-sigs/agent-sandbox/issues/1565#issuecomment-5640229437) — mostly stale-PR clone conflicts, plus a perf gate that fails after junit is written (junit emission for that gate is handled in a separate PR).

## Changes

1. **Exclude aborted runs.** For each red Overall column, the run's `finished.json` is fetched from GCS over HTTPS (via the per-build pointer file for `pr-logs/directory` tabs); `"result": "ABORTED"` columns are dropped from infra counts. Their junit "errors" are also excluded from per-test flake tallies and the consistent-failure check, closing the KNOWN LIMITATION noted on 2026-09-04.
2. **Exclude clone failures.** A red run whose `clone-records.json` shows `"failed": true` **with a verified merge conflict in the git output** is counted separately and reported as "N red run(s) were stale-PR clone failures (rebase needed)". Clone failures without a conflict (network, ref-fetch) and junit-less red runs with no `clone-records.json` at all stay in the infra count — the cause cannot be proven benign, so the classifier is deliberately conservative (regression-tested).
3. **Reclassify junit-present/zero-failing/job-red as pre-test PR breakage**, reported under a new report section. Only "pod started, produced no junit, not aborted/clone-failed" remains infra.

Artifacts are fetched only for the red columns under consideration, so a mostly-green window stays cheap. The `--json` payload keeps the existing `flaky`/`consistent`/`infra` keys and adds `aborted_runs`, `clone_failures`, `pretest_failures` per tab for the daily pipeline.

## Testing

- Classification is factored into pure functions (`classify_red_run`, `column_build_id`, `make_artifact_fetcher`) and covered by a new network-free unit suite `dev/tools/flake_report_test.py` (17 tests), wired into the existing `dev/tools` pytest run under `make test-unit`. Full `dev/tools` suite: 105 tests pass.
- Live read-only run on `presubmit-test-unit` (window 100): 52 red runs → 37 aborted + 7 clone failures + 5 pre-test breakage + 1 infra (previously all 52 would have been infra candidates). Kwok lane: 24 red → 14 aborted + 7 clone failures + 1 pre-test + 2 infra.

Fixes #1566
Part of #1565

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Flake reports now distinguish aborted runs, test failures, pre-test failures, verified clone merge-conflict failures, and infrastructure failures.
  - Network and ref-fetch clone errors remain classified as infrastructure failures.
  - Missing clone records no longer trigger clone-failure classification.
  - Aborted runs and columns are excluded from flake counts and findings.
  - Build identifiers are resolved from the final segment of column IDs.
  - Flaky-status cells are treated as failing tests when classifying red runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
